### PR TITLE
Potential fix for code scanning alert no. 6: Shell command built from environment values

### DIFF
--- a/scripts/generate-cli-docs.js
+++ b/scripts/generate-cli-docs.js
@@ -10,7 +10,7 @@
  * 4. Outputs to docs/cli/commands.md
  */
 
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import { writeFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -35,10 +35,14 @@ if (!existsSync(CLI_REPO)) {
  */
 function runCliCommand(args = []) {
   try {
-    const output = execSync(`node ${CLI_REPO}/dist/index.js ${args.join(' ')}`, {
-      encoding: 'utf8',
-      cwd: CLI_REPO
-    });
+    const output = execFileSync(
+      'node',
+      [`${CLI_REPO}/dist/index.js`, ...args],
+      {
+        encoding: 'utf8',
+        cwd: CLI_REPO
+      }
+    );
     return output;
   } catch (error) {
     return error.stdout || error.message;


### PR DESCRIPTION
Potential fix for [https://github.com/alternatefutures/altfutures-docs/security/code-scanning/6](https://github.com/alternatefutures/altfutures-docs/security/code-scanning/6)

To fix the issue, we should avoid constructing shell commands via string interpolation when passing environment-derived values (like file paths). Instead, use `execFileSync` from `child_process`, which accepts an executable and an array of arguments, so paths and arguments are passed directly without shell parsing or interpretation of special characters.

Specifically:
- In the `runCliCommand` function (lines 36–46), replace building the shell string with calling `execFileSync`, passing the path to NodeJS and the script to run as array elements, along with the argument array `args` (also as array elements).
- Add necessary import for `execFileSync` if not yet imported.

This guarantees all arguments/paths are passed safely, with no shell interpretation. Only code inside the shown file region should be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
