### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/af-deploy-common.yml
+++ b/.github/workflows/af-deploy-common.yml
@@ -1,4 +1,6 @@
 name: ⚡️ Deploy Documentation (Common)
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/alternatefutures/altfutures-docs/security/code-scanning/4](https://github.com/alternatefutures/altfutures-docs/security/code-scanning/4)

To fix the issue, add a `permissions` block either at the root of the workflow file or as part of the job definition (since the workflow only contains one job, either approach suffices). The block should explicitly restrict permissions of the GITHUB_TOKEN to the minimal required for the workflow to function: for most documentation deploy workflows, this will usually be `contents: read`, unless steps require further permissions (eg, `issues: write` or `pull-requests: write`). In the provided snippet, none of the steps appear to write to the repository, so `contents: read` suffices as a starting point. The change should be made by inserting the block after the `name:` line (root level), or inside the job definition. Since this workflow is already using secrets for GitHub authentication, further elevation (eg, `contents: write`) can be added if future workflow changes require it.

Implementing this fix requires:
- Inserting a permissions block, `permissions:\n  contents: read` at the root level (after the `name:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
