### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/af-deploy-production.yml
+++ b/.github/workflows/af-deploy-production.yml
@@ -1,4 +1,6 @@
 name: ⚡️ Deploy Documentation (Production)
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/alternatefutures/altfutures-docs/security/code-scanning/3](https://github.com/alternatefutures/altfutures-docs/security/code-scanning/3)

To fix the issue, you should add a `permissions` block specifying the minimal permissions required for the workflow. The best security practice is to set lower, read-only permissions at the workflow root level (so all jobs inherit them), unless there are specific reasons the deployed job needs more. The most minimal and recommended setting for most deploy workflows is:

```yaml
permissions:
  contents: read
```

This allows the workflow to read repository code but not make changes or access more privileged scopes. If greater permissions are needed for deployment purposes (for example, to create releases or modify code), you can refine the settings as required by the actual workflow logic. The explicit permissions block should be added at the root of the workflow, just after the `name` field and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
