### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/af-deploy-staging.yml
+++ b/.github/workflows/af-deploy-staging.yml
@@ -1,4 +1,6 @@
 name: ⚡️ Deploy Documentation (Staging)
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/alternatefutures/altfutures-docs/security/code-scanning/2](https://github.com/alternatefutures/altfutures-docs/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the workflow file `.github/workflows/af-deploy-staging.yml`. This block should be added at the workflow root (directly under `name: ...`) to clarify the permissions that jobs in this workflow get unless they specify their own. As a minimal starting point, use `contents: read` to minimize access; if later jobs or reusable workflows need more (e.g., to write to pull requests), then add the relevant granular write permissions (e.g., `pull-requests: write`). 

Insert the following block near the top of the file, after `name:` and before the `on:` trigger block. No changes to imports or other job semantics are required to implement this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
