### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/af-deploy-develop.yml
+++ b/.github/workflows/af-deploy-develop.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   deploy-to-develop:
+    permissions:
+      contents: read
     uses: ./.github/workflows/af-deploy-common.yml
     with:
       environment: develop


### PR DESCRIPTION
Potential fix for [https://github.com/alternatefutures/altfutures-docs/security/code-scanning/1](https://github.com/alternatefutures/altfutures-docs/security/code-scanning/1)

To fix this problem, we should add a `permissions` block that explicitly declares the least privilege required by the workflow or the individual job. It can be added at the workflow root (to apply to all jobs) or under the specific job that invokes the reusable workflow. Since the only job in this workflow is `deploy-to-develop`, you can add it under that job. As a minimal safe default (advised by GitHub), specify `contents: read`, which grants read-only access to repository contents. If more permissions are needed, you should tailor this further, but lacking further details, `contents: read` is the appropriate starting point.  

**Required change:**  
- Add a `permissions:` block under the `deploy-to-develop` job, before the `uses` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
