### PR TITLE
docs: ground all docs in real code + preserve unfinished parts as commented roadmap

### DIFF
--- a/docs/brand-guide.md
+++ b/docs/brand-guide.md
@@ -783,7 +783,7 @@ The developer typeface. Every code block, inline code reference, terminal output
 <div class="type-specimen">
   <div class="font-label">JetBrains Mono -- Regular 400 / Medium 500 / SemiBold 600 / Bold 700</div>
   <div class="sample-display" style="font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 1.8rem;">
-    acc deploy --network ipfs
+    acc services deploy
   </div>
   <div class="sample-code" style="font-family: 'JetBrains Mono', ui-monospace, monospace;">
     const af = new AlternateFuturesSdk({<br/>
@@ -1169,7 +1169,7 @@ The same voice can shift tone depending on context:
 
 | Context | Tone | Example |
 |---------|------|---------|
-| **Documentation** | Instructional, precise, neutral | "Run `acc deploy` to push your site to IPFS. The CLI will return a CID and preview URL." |
+| **Documentation** | Instructional, precise, neutral | "Run `acc services deploy` to push your site to IPFS. The CLI will return a CID and preview URL." |
 | **Blog posts** | Conversational, informative | "We shipped a big update this week -- here is what changed and why it matters for your workflow." |
 | **Error messages** | Helpful, never blaming | "Deployment failed: the build command exited with code 1. Check your package.json scripts." |
 | **Social media** | Energetic, concise | "60% cheaper than Vercel. Same features. Decentralized infrastructure. Your margins intact." |
@@ -1185,7 +1185,7 @@ Always use these standard terms:
 | **Alternate Futures** | Full company name (first mention in any document) | "Alt Futures", "AltFut", "A.F." |
 | **AF** | Acceptable abbreviation after first mention | Any other abbreviation |
 | **deploy** | Lowercase verb for the deployment action | "push", "ship", "launch" (in technical docs) |
-| **site** | A static website deployment | "app" (when referring to static hosting) |
+| **site** | A static website deployment (deployed via the `acc services` command) | "app" (when referring to static hosting) |
 | **function** | A serverless cloud function | "lambda", "endpoint" |
 | **agent** | An AI agent deployment | "bot", "model" (when referring to hosted agents) |
 | **decentralized** | Preferred. Describes the infrastructure model | "distributed" (unless technically accurate) |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,28 +22,29 @@ The Alternate Futures platform enters public beta, providing decentralized cloud
 - **Observability** - Distributed tracing, metrics, and logging for all deployments
 - **Billing** - Usage-based pricing with Stripe integration and credit system
 
-### CLI v1.0
+### CLI v0.2 ([`@alternatefutures/cli` package.json](https://github.com/alternatefutures/cloud-cli/blob/main/package.json))
 
 **Released: February 2026**
 
 The `@alternatefutures/cli` package is now available on npm. The CLI binary is `acc`.
 
-- `acc login` - Interactive browser-based authentication
-- `acc sites init` - Initialize site configuration with framework detection
-- `acc sites deploy` - Deploy to IPFS, Filecoin, or Arweave
-- `acc sites list` - View all sites and deployments
-- `acc storage add` - Upload files to decentralized storage
+- `acc login` / `acc logout` - Interactive browser-based authentication
+- `acc projects` - Manage projects and organizations
+- `acc services` - Create, list, deploy, tail logs for, close, and delete services
+- `acc deployments` - View deployment history
+- `acc billing balance` - Check your credit balance
+- `acc ssh` - Manage SSH access
 - `acc pat create` - Generate Personal Access Tokens for automation
-- `acc projects list` - Manage projects and organizations
-- Automatic framework detection for React, Next.js, Vue, Astro, SvelteKit, Hugo, and more
 - JSON output mode for scripting and CI/CD integration
 - Environment variable support (`AF_TOKEN`, `AF_PROJECT_ID`)
+
+See the full [command registration in `src/cli.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts).
 
 ```bash
 npm install -g @alternatefutures/cli
 ```
 
-### SDK v1.0
+### SDK v0.2 ([`@alternatefutures/sdk` package.json](https://github.com/alternatefutures/package-cloud-sdk/blob/main/package.json))
 
 **Released: February 2026**
 
@@ -68,15 +69,13 @@ npm install @alternatefutures/sdk
 
 Starter templates for popular frameworks, pre-configured for Alternate Futures deployment:
 
-- [template-react](https://github.com/alternatefutures/template-react) - React + Vite starter
-- [template-nextjs](https://github.com/alternatefutures/template-nextjs) - Next.js static export starter
-- [template-vue](https://github.com/alternatefutures/template-vue) - Vue.js + Vite starter
-- [template-astro](https://github.com/alternatefutures/template-astro) - Astro starter
-- [template-sveltekit](https://github.com/alternatefutures/template-sveltekit) - SvelteKit static adapter starter
-- [template-hugo](https://github.com/alternatefutures/template-hugo) - Hugo static site starter
-- [template-vitepress](https://github.com/alternatefutures/template-vitepress) - VitePress documentation starter
+- [template-cloud-react](https://github.com/alternatefutures/template-cloud-react) - React + Vite starter
+- [template-cloud-nextjs](https://github.com/alternatefutures/template-cloud-nextjs) - Next.js static export starter
+- [template-cloud-vue](https://github.com/alternatefutures/template-cloud-vue) - Vue.js + Vite starter
+- [template-cloud-astro](https://github.com/alternatefutures/template-cloud-astro) - Astro starter
+- [template-cloud-hugo](https://github.com/alternatefutures/template-cloud-hugo) - Hugo static site starter
 
-Each template includes an `af.config.json` with the correct build command and output directory pre-configured.
+Each template ships with its framework config (e.g. `vite.config.ts`, `next.config.js`, `astro.config.mjs`) and a ready-to-build `package.json`.
 
 ### Documentation Site
 
@@ -87,7 +86,7 @@ Comprehensive documentation at [docs.alternatefutures.ai](https://docs.alternate
 - Getting started guides and quickstart tutorial
 - Framework-specific deployment guides (Next.js, React, Astro)
 - CLI command reference
-- SDK API reference (auto-generated from TypeDoc)
+- SDK API reference
 - Migration guides from Fleek, Netlify, Spheron, and Vercel
 - CI/CD integration for GitHub Actions, GitLab CI, CircleCI, and Jenkins
 - Infrastructure guides for the decentralized container registry

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -348,13 +348,14 @@ acc --version
 
 <!-- ROADMAP — not yet shipped. Uncomment each section as the feature ships.
 
-## Roadmap (not yet available)
+## Removed / re-architected commands (kept for reference)
 
-The commands below were previously documented but are **not yet implemented** in
-the `acc` CLI. They are preserved here (commented out) so they are ready to
-uncomment when the corresponding feature ships.
+These Fleek-legacy commands were removed from the CLI in cloud-cli#64 and are not planned as CLI commands in their original form. Current direction is noted per feature. Triage: cloud-cli#118.
 
 ### `acc signup`
+
+STATUS: Handler exists but is not registered in cli.ts.
+
 Create a new Alternate Futures account using email verification.
 
 ```bash
@@ -362,6 +363,8 @@ acc signup
 ```
 
 ## Sites
+
+STATUS: Removed in cloud-cli#64. Static-site hosting is now via the dashboard.
 
 Deploy and manage static sites on decentralized infrastructure.
 
@@ -434,6 +437,8 @@ acc sites ci --provider gitlab    # GitLab CI
 
 ## Storage
 
+STATUS: Removed. Object storage is now the rustfs S3 BUCKET service template (`acc services create`).
+
 Manage files on decentralized storage (IPFS + Filecoin/Arweave backup).
 
 ### `acc storage add`
@@ -490,6 +495,8 @@ acc storage delete --cid QmXxx...
 
 ## IPFS
 
+STATUS: Removed as a standalone command. IPFS pinning is internal to the deploy pipeline / dashboard.
+
 Direct IPFS operations for decentralized content storage.
 
 ### `acc ipfs add`
@@ -507,6 +514,8 @@ Returns the content identifier (CID) for the uploaded content.
 
 
 ## IPNS
+
+STATUS: Removed from the CLI. Handled via the DNS / custom-domain flow (backend WIP).
 
 InterPlanetary Naming System for mutable content addressing.
 
@@ -573,6 +582,8 @@ acc ipns delete --name my-website
 
 
 ## Functions
+
+STATUS: No longer a standalone group. Now a 'Function' kind inside `acc services create` (coming soon there).
 
 Deploy serverless functions to decentralized infrastructure.
 
@@ -659,6 +670,8 @@ acc functions deployments --name my-function
 
 ## Domains
 
+STATUS: Removed. Custom domains are managed in the dashboard.
+
 Manage custom domains for your sites and gateways.
 
 ### `acc domains list`
@@ -730,6 +743,8 @@ acc domains delete --hostname www.example.com
 
 
 ## ENS
+
+STATUS: Removed from the CLI. ENS backend is planned (service-cloud-api#64).
 
 Ethereum Name Service integration for .eth domains.
 
@@ -803,6 +818,8 @@ acc ens delete --domain myapp.eth
 
 ## Gateways
 
+STATUS: Removed from the CLI. Private-gateway backend is not yet built.
+
 Manage private IPFS gateways for your content.
 
 ### `acc gateways list`
@@ -859,6 +876,8 @@ acc gateways delete --id gw_abc123
 
 
 ## Applications
+
+STATUS: Removed (Fleek-legacy). Product intent under review.
 
 Manage SDK application Client IDs.
 
@@ -917,6 +936,8 @@ acc applications delete --id app_abc123
 
 
 ## Observability
+
+STATUS: No longer a separate group. Use `acc services logs`, plus SDK/API observability.
 
 Query and manage APM observability data (traces, logs, metrics). Use `acc observability` or the short alias `acc obs`.
 
@@ -1111,6 +1132,8 @@ acc obs settings:update --sample-rate 0.1 --trace-retention 7 --log-retention 7
 
 ## Agents
 
+STATUS: Not a deployable-runtime CLI group. Deployable agents are templates via `acc services`/templates; `acc chat` provides chat orchestration.
+
 Deploy and manage AI agents on decentralized infrastructure. Supported agent types include Eliza (conversational AI), ComfyUI (image generation), and custom agents.
 
 ### `acc agents create`
@@ -1207,6 +1230,8 @@ acc agents delete <agent-id>
 
 
 ## Billing
+
+STATUS: Only `acc billing balance` ships; the other billing subcommands are not implemented.
 
 View billing information and usage metrics.
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -1,94 +1,365 @@
 ---
-description: Complete reference for all Alternate Futures CLI (af) commands including sites, storage, domains, functions, agents, and more.
+description: Complete reference for the Alternate Clouds CLI (acc) — authentication, projects, services, deployments, SSH, personal access tokens, templates, and billing.
 ---
 
-# CLI Commands Reference
+# CLI Commands
 
-Complete reference for all Alternate Futures CLI (`acc`) commands.
+Complete reference for the commands the Alternate Clouds CLI (`acc`) ships today. Every command below is verified against the `cloud-cli` source.
 
-## Command Structure
+::: tip New to the CLI?
+Start with the [CLI overview](./index) for installation, quick start, environment variables, and the `af.config` file. This page is the per-command reference.
+:::
+
+Get help for any command directly from your terminal:
 
 ```bash
-acc <command> [subcommand] [options]
+acc --help                 # Top-level help
+acc services --help        # Help for a command group
+acc services deploy --help # Help for a single command
 ```
+
+## Command Groups
+
+| Command | Description |
+|---------|-------------|
+| [`acc login`](#acc-login) / [`acc logout`](#acc-logout) | Authenticate or end your CLI session |
+| [`acc projects`](#acc-projects) | Create, list, switch, rename, and delete projects |
+| [`acc services`](#acc-services) | Create, deploy, inspect, and manage services |
+| [`acc deployments`](#acc-deployments) | List and filter deployments |
+| [`acc ssh`](#acc-ssh) | Open an interactive shell in a running deployment |
+| [`acc pat`](#acc-pat) | Manage personal access tokens |
+| [`acc templates`](#acc-templates) | Browse service templates |
+| [`acc billing`](#acc-billing) | View your credit balance |
+| [`acc version`](#acc-version) | Print the installed CLI version |
 
 ## Authentication
 
 ### `acc login`
 
-Authenticate your CLI session.
+Log in to Alternate Clouds. By default this opens your browser to the web UI to complete authentication. Pass `--email` to authenticate with an email verification code instead — useful on headless machines with no browser.
 
 ```bash
-acc login              # Opens browser for authentication
-acc login --email      # Login via email verification (no browser)
+acc login              # Browser-based login (default)
+acc login --email      # Email verification code (no browser)
 ```
-
-**Options:**
 
 | Option | Description |
 |--------|-------------|
-| `-e, --email` | Login via email verification (no browser required) |
-| `--auth-url <url>` | Override auth service URL (for testing) |
+| `-e, --email` | Log in via email verification instead of a browser |
+| `--auth-url <url>` | Override the auth service URL (e.g. `http://localhost:3001`) |
+
+> **What this maps to in code:** the command is registered in [`cli.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts). Browser login runs [`login.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/auth/login.ts); `--email` runs [`loginEmail.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/auth/loginEmail.ts).
 
 ### `acc logout`
 
-End your active CLI session.
+End your CLI session and clear stored credentials.
 
 ```bash
 acc logout
 ```
 
-### `acc signup`
-
-Create a new Alternate Futures account using email verification.
-
-```bash
-acc signup
-```
-
----
+> **What this maps to in code:** registered in [`cli.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts), handled by [`logout.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/auth/logout.ts).
 
 ## Projects
 
-Manage your projects and switch between them.
+Manage your projects. Running `acc projects` with no subcommand lists your projects.
 
-### `acc projects list`
+### `acc projects`
 
-Display all projects where you are a member.
+```bash
+acc projects           # Same as `acc projects list`
+```
+
+#### `acc projects list`
+
+List all projects.
 
 ```bash
 acc projects list
 ```
 
-### `acc projects create`
+#### `acc projects create`
 
-Create a new project.
+Create a new project. If `--name` is omitted, the CLI prompts for one.
 
 ```bash
+acc projects create
 acc projects create --name "my-project"
 ```
 
-**Options:**
-
 | Option | Description |
 |--------|-------------|
-| `--name <name>` | Name for the new project |
+| `--name <string>` | Project name |
 
-### `acc projects switch`
+#### `acc projects update`
 
-Switch to a different project.
+Rename a project. Pass the project ID as a positional argument, or run without one to select interactively.
 
 ```bash
-acc projects switch --id prj_abc123
+acc projects update
+acc projects update prj_abc123
 ```
 
-**Options:**
+#### `acc projects switch`
+
+Switch the active project. Subsequent commands use the selected project by default.
+
+```bash
+acc projects switch
+acc projects switch prj_abc123
+```
+
+#### `acc projects delete`
+
+Delete a project and all of its services.
+
+```bash
+acc projects delete
+acc projects delete prj_abc123
+```
+
+> **What this maps to in code:** all `projects` subcommands are wired up in [`projects/index.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/projects/index.ts).
+
+## Services
+
+Services are the deploy path for Alternate Clouds. Create a service from a template, then deploy it to decentralized compute. Running `acc services` with no subcommand lists services in the current (or selected) project.
+
+All `services` subcommands accept a `-p, --project <id-or-name>` flag to target a specific project instead of the active one.
+
+### `acc services`
+
+```bash
+acc services                        # List services in the active project
+acc services -p my-project          # List services in a specific project
+```
+
+#### `acc services list`
+
+List all services in the project.
+
+```bash
+acc services list
+```
+
+#### `acc services create`
+
+Create a new service from a template. Runs interactive prompts to choose the template and configure the service.
+
+```bash
+acc services create
+```
+
+#### `acc services info`
+
+Show details for a service. Pass a service ID or select interactively.
+
+```bash
+acc services info
+acc services info svc_abc123
+```
+
+#### `acc services deploy`
+
+Deploy (or redeploy) a service.
+
+```bash
+acc services deploy
+acc services deploy svc_abc123
+```
+
+#### `acc services logs`
+
+Fetch logs for a service.
+
+```bash
+acc services logs
+acc services logs svc_abc123 --tail 100
+```
 
 | Option | Description |
 |--------|-------------|
-| `--id <projectId>` | Project ID to switch to |
+| `--tail <n>` | Number of log lines to show (default: `50`) |
 
----
+#### `acc services close`
+
+Close the active deployment on a service (stops it without deleting the service).
+
+```bash
+acc services close
+acc services close svc_abc123
+```
+
+#### `acc services delete`
+
+Delete a service. If a deployment is running, it is closed first.
+
+```bash
+acc services delete
+acc services delete svc_abc123
+```
+
+> **What this maps to in code:** every `services` subcommand — including the `deploy` path — is registered in [`services/index.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/services/index.ts); the deploy handler lives in [`services/deploy.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/services/deploy.ts).
+
+## Deployments
+
+List and view deployments across all projects and services. Running `acc deployments` with no subcommand lists deployments; `acc deployments list` does the same.
+
+By default only active deployments (`ACTIVE`, `DEPLOYING`, `INITIALIZING`, `QUEUED`, `BUILDING`) are shown. Pass `--all` to include closed and old deployments.
+
+### `acc deployments`
+
+```bash
+acc deployments                          # Active deployments only
+acc deployments --all                    # Include closed/old deployments
+acc deployments --project my-project     # Filter by project
+acc deployments --service api            # Filter by service (name or ID)
+acc deployments --status failed          # Filter by status
+acc deployments --limit 100              # Cap the number of rows
+```
+
+| Option | Description |
+|--------|-------------|
+| `--project <name-or-id>` | Filter by project |
+| `--service <name-or-id>` | Filter by service |
+| `--status <status>` | Filter by status (e.g. `active`, `failed`, `closed`) |
+| `--all` | Include closed and old deployments |
+| `-l, --limit <n>` | Max deployments to show (default: `50`) |
+
+#### `acc deployments list`
+
+Alias for the above; accepts the same options.
+
+```bash
+acc deployments list --status active
+```
+
+> **What this maps to in code:** the `deployments` group and its filtering logic are in [`deployments/index.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/deployments/index.ts).
+
+## SSH
+
+### `acc ssh`
+
+Open an interactive shell in a running deployment. The service ID is required.
+
+```bash
+acc ssh svc_abc123
+acc ssh svc_abc123 --command "/bin/sh"
+acc ssh svc_abc123 --service worker      # For multi-service deployments
+```
+
+| Argument / Option | Description |
+|-------------------|-------------|
+| `<serviceId>` | Service to connect to (required) |
+| `--service <name>` | SDL service name, for multi-service deployments |
+| `--command <cmd>` | Command to run (default: `/bin/bash`) |
+
+> **What this maps to in code:** registered in [`ssh/index.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/ssh/index.ts).
+
+## Personal Access Tokens
+
+Manage personal access tokens (PATs) for CI/CD and automation. Use a PAT with the `AF_TOKEN` environment variable to authenticate non-interactively.
+
+### `acc pat list`
+
+List your personal access tokens.
+
+```bash
+acc pat list
+```
+
+### `acc pat create`
+
+Create a new personal access token.
+
+```bash
+acc pat create
+acc pat create --name "ci-pipeline"
+```
+
+| Option | Description |
+|--------|-------------|
+| `-n, --name <name>` | Name for the new token |
+
+### `acc pat delete`
+
+Delete a personal access token by ID.
+
+```bash
+acc pat delete <personalAccessTokenId>
+```
+
+> **What this maps to in code:** the `pat` group is defined in [`pat/index.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/pat/index.ts).
+
+## Templates
+
+Browse the service templates available for `acc services create`. Running `acc templates` with no subcommand lists all templates.
+
+### `acc templates list`
+
+List available templates, optionally filtered by category.
+
+```bash
+acc templates list
+acc templates list --category AI_ML
+```
+
+| Option | Description |
+|--------|-------------|
+| `-c, --category <category>` | Filter by category: `AI_ML`, `WEB_SERVER`, `GAME_SERVER`, `DATABASE`, `DEVTOOLS`, `CUSTOM` |
+
+### `acc templates info`
+
+Show detailed information for a template.
+
+```bash
+acc templates info <templateId>
+```
+
+> **What this maps to in code:** the `templates` group is defined in [`templates/index.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/templates/index.ts).
+
+## Billing
+
+### `acc billing balance`
+
+Show your current credit balance.
+
+```bash
+acc billing balance
+```
+
+::: info Only `balance` is available today
+`acc billing` currently implements a single subcommand: `balance`. Additional billing commands are planned but not yet shipped.
+:::
+
+> **What this maps to in code:** the `billing` group is registered in [`billing/index.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/billing/index.ts), with the handler in [`billing/balance.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/billing/balance.ts).
+
+## Version
+
+### `acc version`
+
+Print the installed CLI version. `acc --version` prints the same value.
+
+```bash
+acc version
+acc --version
+```
+
+> **What this maps to in code:** the `version` command and `--version` flag are wired up in [`cli.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts).
+
+<!-- ROADMAP — not yet shipped. Uncomment each section as the feature ships.
+
+## Roadmap (not yet available)
+
+The commands below were previously documented but are **not yet implemented** in
+the `acc` CLI. They are preserved here (commented out) so they are ready to
+uncomment when the corresponding feature ships.
+
+### `acc signup`
+Create a new Alternate Futures account using email verification.
+
+```bash
+acc signup
+```
 
 ## Sites
 
@@ -160,6 +431,7 @@ acc sites ci --provider gitlab    # GitLab CI
 
 ---
 
+
 ## Storage
 
 Manage files on decentralized storage (IPFS + Filecoin/Arweave backup).
@@ -215,6 +487,7 @@ acc storage delete --cid QmXxx...
 
 ---
 
+
 ## IPFS
 
 Direct IPFS operations for decentralized content storage.
@@ -231,6 +504,7 @@ acc ipfs add ./my-folder
 Returns the content identifier (CID) for the uploaded content.
 
 ---
+
 
 ## IPNS
 
@@ -296,6 +570,7 @@ acc ipns delete --name my-website
 | `--name <name>` | IPNS name to delete |
 
 ---
+
 
 ## Functions
 
@@ -381,6 +656,7 @@ acc functions deployments --name my-function
 
 ---
 
+
 ## Domains
 
 Manage custom domains for your sites and gateways.
@@ -451,6 +727,7 @@ acc domains delete --hostname www.example.com
 | `--hostname <hostname>` | Domain to delete |
 
 ---
+
 
 ## ENS
 
@@ -523,6 +800,7 @@ acc ens delete --domain myapp.eth
 
 ---
 
+
 ## Gateways
 
 Manage private IPFS gateways for your content.
@@ -578,6 +856,7 @@ acc gateways delete --id gw_abc123
 | `--id <gatewayId>` | Gateway ID to delete |
 
 ---
+
 
 ## Applications
 
@@ -636,41 +915,6 @@ acc applications delete --id app_abc123
 
 ---
 
-## Personal Access Tokens
-
-Manage tokens for API and CLI authentication.
-
-### `acc pat list`
-
-List all personal access tokens.
-
-```bash
-acc pat list
-```
-
-### `acc pat create`
-
-Generate a new personal access token.
-
-```bash
-acc pat create --name "CI/CD Token"
-```
-
-**Options:**
-
-| Option | Description |
-|--------|-------------|
-| `--name <name>` | Token name |
-
-### `acc pat delete`
-
-Revoke a personal access token.
-
-```bash
-acc pat delete pat_abc123
-```
-
----
 
 ## Observability
 
@@ -864,6 +1108,7 @@ acc obs settings:update --sample-rate 0.1 --trace-retention 7 --log-retention 7
 
 ---
 
+
 ## Agents
 
 Deploy and manage AI agents on decentralized infrastructure. Supported agent types include Eliza (conversational AI), ComfyUI (image generation), and custom agents.
@@ -960,6 +1205,7 @@ acc agents delete <agent-id>
 
 ---
 
+
 ## Billing
 
 View billing information and usage metrics.
@@ -1013,45 +1259,5 @@ acc billing payment-methods
 
 ---
 
-## Global Options
 
-Available for all commands:
-
-| Option | Description |
-|--------|-------------|
-| `--debug` | Enable debug output |
-| `-V, --version` | Show CLI version |
-| `-h, --help` | Show help for command |
-
-## Getting Help
-
-```bash
-# General help
-acc --help
-
-# Help for a command group
-acc sites --help
-
-# Help for a specific subcommand
-acc sites deploy --help
-```
-
-## Environment Variables
-
-For CI/CD and automation:
-
-| Variable | Description |
-|----------|-------------|
-| `AF_TOKEN` | Personal access token for authentication |
-| `AF_PROJECT_ID` | Default project ID |
-| `AF_BASE_URL` | Override API endpoint (for testing) |
-
-Example:
-
-```bash
-export AF_TOKEN="your-personal-access-token"
-export AF_PROJECT_ID="prj_abc123"
-
-# Commands now use these credentials
-acc sites deploy
-```
+-->

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -176,9 +176,9 @@ acc templates info <templateId>
 
 <!-- ROADMAP — not yet shipped. Uncomment when implemented.
 
-## Roadmap (not yet available)
+## Removed / re-architected commands (kept for reference)
 
-The following capabilities are documented for reference but are **not yet implemented** in the `acc` CLI. Uncomment each section when the corresponding feature ships.
+These Fleek-legacy commands were removed from the CLI in cloud-cli#64 and are not planned as CLI commands in their original form. Current direction is noted per feature. Triage: cloud-cli#118.
 
 ### Planned features
 
@@ -206,6 +206,8 @@ The following capabilities are documented for reference but are **not yet implem
 
 ### Deploy a React Site
 
+STATUS: Removed in cloud-cli#64. Static-site hosting is now via the dashboard.
+
 ```bash
 # Build your app
 npm run build
@@ -220,6 +222,8 @@ acc sites deploy
 
 ### Generate CI/CD Config
 
+STATUS: Removed in cloud-cli#64. Static-site hosting is now via the dashboard.
+
 ```bash
 # Generate GitHub Actions workflow
 acc sites ci --provider github
@@ -228,6 +232,8 @@ acc sites ci --provider github
 This creates `.github/workflows/af-deploy.yml` for automatic deployments.
 
 ### Upload Files to IPFS
+
+STATUS: Removed. Object storage is now the rustfs S3 BUCKET service template (`acc services create`).
 
 ```bash
 # Upload a single file
@@ -241,6 +247,8 @@ acc storage list
 ```
 
 ### Work with Custom Domains
+
+STATUS: Removed. Custom domains are managed in the dashboard.
 
 ```bash
 # Add a domain to your site

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,19 +1,19 @@
 ---
-description: The Alternate Futures CLI (af) lets you deploy sites, manage storage, configure domains, and run AI agents from the command line.
+description: The Alternate Clouds CLI (acc) lets you manage projects, deploy services from templates, inspect deployments, open a shell into a running service, and check your billing balance.
 ---
 
 # CLI Documentation
 
-The Alternate Futures CLI (`acc`) provides a powerful command-line interface for managing your agents, sites, storage, and deployments on decentralized infrastructure.
+The Alternate Clouds CLI (`acc`) is the command-line interface for Alternate Clouds. Use it to authenticate, manage projects, create and deploy services from templates, inspect deployments, open a shell into a running service, and check your billing balance.
 
 ## Features
 
-- **Deploy Sites** - Push static sites to IPFS, Filecoin, or Arweave
-- **Manage Storage** - Upload and manage files on decentralized storage
-- **Configure Domains** - Add custom domains and ENS integration
-- **Serverless Functions** - Deploy and manage edge functions
-- **CI/CD Integration** - Generate workflow configs for GitHub Actions, GitLab CI, and more
-- **Billing & Usage** - Monitor costs and resource consumption
+- **Authenticate** - Log in via browser or email verification code
+- **Manage projects** - Create, list, switch, rename, and delete projects
+- **Deploy services** - Create services from templates and deploy them to decentralized compute (Akash/Phala)
+- **Inspect deployments** - List and filter deployments across projects and services
+- **Open a shell** - SSH into a running service
+- **Check billing** - View your current credit balance
 
 ## Installation
 
@@ -48,37 +48,30 @@ acc --version
 acc login
 
 # 2. Create a new project
-acc projects create --name "my-website"
+acc projects create --name "my-project"
 
-# 3. Initialize site configuration
-acc sites init
+# 3. Create a service from a template (interactive)
+acc services create
 
-# 4. Deploy your site
-acc sites deploy
+# 4. Deploy the service
+acc services deploy
 
 # 5. View your deployments
-acc sites list
+acc deployments list
 ```
 
 ## Command Groups
 
 | Command | Description |
 |---------|-------------|
-| `acc login` / `acc logout` | Authentication |
-| `acc projects` | Manage projects |
-| `acc sites` | Deploy and manage static sites |
-| `acc functions` | Serverless function management |
-| `acc storage` | Decentralized storage operations |
-| `acc ipfs` | Direct IPFS operations |
-| `acc ipns` | IPNS record management |
-| `acc domains` | Custom domain configuration |
-| `acc ens` | ENS domain integration |
-| `acc gateways` | Private IPFS gateways |
-| `acc agents` | AI agent deployment and management |
-| `acc observability` | APM observability (traces, logs, metrics) |
-| `acc applications` | SDK application management |
-| `acc pat` | Personal access tokens |
-| `acc billing` | Billing and usage information |
+| `acc login` / `acc logout` | Authenticate or end your CLI session |
+| `acc projects` | Create, list, switch, rename, and delete projects |
+| `acc services` | Create, deploy, inspect, and manage services |
+| `acc deployments` | List and filter deployments |
+| `acc ssh` | Open a shell into a running service |
+| `acc billing` | View your credit balance |
+
+> **What this maps to in code:** command registration lives in [command registration (cli.ts)](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts). `templates` and `pat` are also registered but hidden from top-level help.
 
 ## Getting Help
 
@@ -89,10 +82,10 @@ The CLI has built-in help for every command:
 acc --help
 
 # Help for a command group
-acc sites --help
+acc services --help
 
 # Help for a specific command
-acc sites deploy --help
+acc services deploy --help
 ```
 
 ## Environment Variables
@@ -108,28 +101,29 @@ export AF_PROJECT_ID="your-project-id"
 |----------|-------------|
 | `AF_TOKEN` | Personal access token for authentication |
 | `AF_PROJECT_ID` | Default project ID for commands |
-| `AF_BASE_URL` | Override API endpoint (for testing) |
+| `AF_ORG_ID` | Default organization ID |
+
+> **What this maps to in code:** these are the only variables the CLI reads — see [CLI environment variables (secrets.ts)](https://github.com/alternatefutures/cloud-cli/blob/main/src/secrets.ts).
 
 ## Configuration File
 
-The CLI uses `af.config.json` for site configuration:
+The CLI reads deployment configuration from an `af.config` file in your project root. It accepts `af.config.ts`, `af.config.js`, or `af.config.json`:
 
 ```json
 {
-  "name": "my-site",
-  "buildCommand": "npm run build",
-  "distDir": "./dist",
-  "storage": {
-    "type": "ipfs"
-  }
+  "sites": [
+    {
+      "slug": "my-site",
+      "distDir": "./dist",
+      "buildCommand": "npm run build"
+    }
+  ]
 }
 ```
 
-Create one with:
+Create the file manually in your project root.
 
-```bash
-acc sites init
-```
+> **What this maps to in code:** the schema (`AlternateFuturesRootConfig` with a `sites[]` array and an optional `functions[]` block) is defined in [af.config type definition](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts).
 
 ## Documentation
 
@@ -138,10 +132,77 @@ acc sites init
 
 ## Requirements
 
-- Node.js 18.0.0 or higher
+- Node.js 18.18.2 or higher
 - npm, pnpm, or yarn
 
 ## Examples
+
+### Deploy a Service
+
+```bash
+# Create a service from a template (interactive prompts)
+acc services create
+
+# Deploy it
+acc services deploy
+
+# Watch its logs
+acc services logs --tail 100
+```
+
+### Manage Multiple Projects
+
+```bash
+# List all projects
+acc projects list
+
+# Switch to a different project (positional project ID)
+acc projects switch prj_production
+
+# All subsequent commands use the selected project
+acc services list
+acc deployments list
+```
+
+### Browse Templates
+
+```bash
+# List templates, optionally filtered by category
+acc templates list --category AI_ML
+
+# Inspect a template
+acc templates info <templateId>
+```
+
+<!-- ROADMAP — not yet shipped. Uncomment when implemented.
+
+## Roadmap (not yet available)
+
+The following capabilities are documented for reference but are **not yet implemented** in the `acc` CLI. Uncomment each section when the corresponding feature ships.
+
+### Planned features
+
+- **Deploy Sites** - Push static sites to IPFS, Filecoin, or Arweave
+- **Manage Storage** - Upload and manage files on decentralized storage
+- **Configure Domains** - Add custom domains and ENS integration
+- **Serverless Functions** - Deploy and manage edge functions
+- **CI/CD Integration** - Generate workflow configs for GitHub Actions, GitLab CI, and more
+
+### Planned command groups
+
+| Command | Description |
+|---------|-------------|
+| `acc sites` | Deploy and manage static sites |
+| `acc functions` | Serverless function management |
+| `acc storage` | Decentralized storage operations |
+| `acc ipfs` | Direct IPFS operations |
+| `acc ipns` | IPNS record management |
+| `acc domains` | Custom domain configuration |
+| `acc ens` | ENS domain integration |
+| `acc gateways` | Private IPFS gateways |
+| `acc agents` | AI agent deployment and management |
+| `acc observability` | APM observability (traces, logs, metrics) |
+| `acc applications` | SDK application management |
 
 ### Deploy a React Site
 
@@ -165,20 +226,6 @@ acc sites ci --provider github
 ```
 
 This creates `.github/workflows/af-deploy.yml` for automatic deployments.
-
-### Manage Multiple Projects
-
-```bash
-# List all projects
-acc projects list
-
-# Switch to a different project
-acc projects switch --id prj_production
-
-# All subsequent commands use the selected project
-acc sites list
-acc domains list
-```
 
 ### Upload Files to IPFS
 
@@ -205,3 +252,6 @@ acc domains detail --hostname www.example.com
 # Verify DNS configuration
 acc domains verify --hostname www.example.com
 ```
+
+-->
+

--- a/docs/cli/installation.md
+++ b/docs/cli/installation.md
@@ -122,7 +122,12 @@ Create a config file in your project root. The CLI accepts `af.config.ts`, `af.c
 
 > **What this maps to in code:** the schema (a top-level `sites[]` array, plus an optional `functions[]` block) is defined in [af.config type definition](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts).
 
-<!-- ROADMAP — not yet shipped. Uncomment when implemented.
+<!-- Removed / re-architected commands (kept for reference)
+
+These Fleek-legacy commands were removed from the CLI in cloud-cli#64 and are not planned as CLI commands in their original form. Current direction is noted per feature. Triage: cloud-cli#118.
+
+STATUS: Removed in cloud-cli#64. Static-site hosting is now via the dashboard.
+
 Initialize a site configuration file in your project:
 
 ```bash
@@ -221,7 +226,10 @@ jobs:
           AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID }}
 ```
 
-<!-- ROADMAP — not yet shipped. Uncomment when implemented.
+<!-- Removed / re-architected commands (kept for reference)
+
+STATUS: Removed in cloud-cli#64. Static-site hosting is now via the dashboard.
+
 Or generate it automatically:
 
 ```bash

--- a/docs/cli/installation.md
+++ b/docs/cli/installation.md
@@ -8,14 +8,16 @@ Complete guide to installing and configuring the Alternate Futures CLI.
 
 ## Requirements
 
-- **Node.js 18.0.0 or higher** - [Download here](https://nodejs.org/)
+- **Node.js 18.18.2 or higher** - [Download here](https://nodejs.org/)
 - **npm, pnpm, or yarn** - Package manager
 
 Check your Node.js version:
 
 ```bash
-node --version  # Should be v18.0.0 or higher
+node --version  # Should be v18.18.2 or higher
 ```
+
+> **What this maps to in code:** the engine range and package name are declared in [package.json engines / bin](https://github.com/alternatefutures/cloud-cli/blob/main/package.json).
 
 ## Installation
 
@@ -61,13 +63,7 @@ Before using the CLI, you need to authenticate with your Alternate Futures accou
 acc login
 ```
 
-This opens your browser where you can sign in with:
-- Email (magic link)
-- Google account
-- GitHub account
-- Web3 wallet (MetaMask, Coinbase Wallet, etc.)
-
-After signing in, the CLI automatically saves your credentials.
+This opens the Alternate Clouds web app in your browser to sign in. The available sign-in methods (email magic link, Google, GitHub, and Web3 wallets) are provided by the web app. After signing in, the CLI automatically saves your credentials.
 
 ### Email Login (No Browser)
 
@@ -92,7 +88,7 @@ export AF_PROJECT_ID="your-project-id"
 1. Log in to [app.alternatefutures.ai](https://app.alternatefutures.ai)
 2. Go to Settings > API Keys
 3. Create a new Personal Access Token
-4. Copy the token (starts with `pat_`)
+4. Copy the token and store it somewhere secure
 
 ## Configuration
 
@@ -104,12 +100,29 @@ If you have multiple projects, select one:
 # List available projects
 acc projects list
 
-# Switch to a project
-acc projects switch --id prj_abc123
+# Switch to a project (positional project ID)
+acc projects switch prj_abc123
 ```
 
 ### Site Configuration
 
+Create a config file in your project root. The CLI accepts `af.config.ts`, `af.config.js`, or `af.config.json`:
+
+```json
+{
+  "sites": [
+    {
+      "slug": "my-site",
+      "distDir": "./dist",
+      "buildCommand": "npm run build"
+    }
+  ]
+}
+```
+
+> **What this maps to in code:** the schema (a top-level `sites[]` array, plus an optional `functions[]` block) is defined in [af.config type definition](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts).
+
+<!-- ROADMAP — not yet shipped. Uncomment when implemented.
 Initialize a site configuration file in your project:
 
 ```bash
@@ -129,39 +142,43 @@ This creates `af.config.json`:
   }
 }
 ```
+-->
+
 
 ## Environment Variables Reference
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `AF_TOKEN` | Personal access token | `pat_abc123...` |
-| `AF_PROJECT_ID` | Default project ID | `prj_def456...` |
-| `AF_BASE_URL` | Override API endpoint | `https://api.custom.com` |
+| `AF_TOKEN` | Personal access token | `<your-token>` |
+| `AF_PROJECT_ID` | Default project ID | `prj_abc123` |
+| `AF_ORG_ID` | Default organization ID | `org_abc123` |
+
+> **What this maps to in code:** these are the only variables the CLI reads — see [env vars read by the CLI](https://github.com/alternatefutures/cloud-cli/blob/main/src/secrets.ts).
 
 ### Setting Environment Variables
 
 **Linux/macOS:**
 ```bash
 # Temporary (current session)
-export AF_TOKEN="pat_abc123..."
+export AF_TOKEN="your-token"
 
 # Permanent (add to ~/.bashrc or ~/.zshrc)
-echo 'export AF_TOKEN="pat_abc123..."' >> ~/.bashrc
+echo 'export AF_TOKEN="your-token"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
 **Windows (PowerShell):**
 ```powershell
 # Temporary
-$env:AF_TOKEN = "pat_abc123..."
+$env:AF_TOKEN = "your-token"
 
 # Permanent
-[Environment]::SetEnvironmentVariable("AF_TOKEN", "pat_abc123...", "User")
+[Environment]::SetEnvironmentVariable("AF_TOKEN", "your-token", "User")
 ```
 
 **Windows (Command Prompt):**
 ```cmd
-set AF_TOKEN=pat_abc123...
+set AF_TOKEN=your-token
 ```
 
 ## CI/CD Setup
@@ -198,17 +215,19 @@ jobs:
         run: npm install -g @alternatefutures/cli
 
       - name: Deploy
-        run: acc sites deploy
+        run: acc services deploy <service-id>
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN }}
           AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID }}
 ```
 
+<!-- ROADMAP — not yet shipped. Uncomment when implemented.
 Or generate it automatically:
 
 ```bash
 acc sites ci --provider github
 ```
+-->
 
 ### GitLab CI
 
@@ -222,7 +241,7 @@ deploy:
     - npm ci
     - npm run build
     - npm install -g @alternatefutures/cli
-    - acc sites deploy
+    - acc services deploy <service-id>
   variables:
     AF_TOKEN: $AF_TOKEN
     AF_PROJECT_ID: $AF_PROJECT_ID

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -1,43 +1,31 @@
 ---
-description: Deploy and manage Eliza, ComfyUI, and custom AI agents on decentralized infrastructure with Alternate Futures.
+description: Create and interact with chat agents on Alternate Clouds using the GraphQL API.
 ---
 
-# Managing AI Agents
+# AI Agents
 
-::: warning Web App Under Development
-The web interface for managing agents is currently under development. Use the [CLI](../cli/) or [SDK](../sdk/) to deploy and manage AI agents.
+::: info What ships today
+Alternate Clouds agents are **chat agents**: a named agent with a system prompt, a model, and an optional linked function. You create an agent, start chats, and send messages via the GraphQL API. Deployable runtimes (Eliza, ComfyUI, custom LangChain/LangGraph) and a start/stop/logs lifecycle are on the roadmap and are not yet available.
 :::
 
-Deploy and manage AI agents on decentralized infrastructure using the CLI or SDK.
+::: tip What this maps to in code
+The [Agent GraphQL type and mutations](https://github.com/alternatefutures/service-cloud-api/blob/main/src/schema/typeDefs.ts) define the real surface: `Agent { id name slug description avatar systemPrompt model status }`, `CreateAgentInput { name, slug, description, systemPrompt, model, functionId }`, and the mutations `createAgent`, `createChat`, `sendMessage`, `deleteChat`.
+:::
 
-## Agent Types
+## What a chat agent is
 
-### Eliza
+An agent is defined by:
 
-Autonomous AI agents with personality and memory:
+- **name / slug** - identity within your project
+- **systemPrompt** - the instructions that shape the agent's behavior
+- **model** - the model that backs the agent
+- **functionId** (optional) - an Alternate Clouds function the agent can call
 
-- Conversational AI with persistent memory
-- Multi-platform support (Discord, Twitter, Telegram)
-- Custom personality configuration via characterfile
-- Plugin ecosystem for extended capabilities
+You then open a chat against the agent and exchange messages.
 
-### ComfyUI
-
-AI image and video generation workflows:
-
-- Stable Diffusion image generation
-- Custom workflow support
-- GPU-accelerated processing
-- API access for programmatic generation
-
-### Custom
-
-Build your own AI agents:
-
-- Deploy custom LangChain/LangGraph agents
-- Full control over agent logic
-- Connect to external APIs and services
-- Custom runtime environments
+::: info Roadmap
+Deployable agent runtimes — Eliza (Discord/Twitter/Telegram, characterfiles, plugins), ComfyUI (Stable Diffusion / GPU workflows), and custom LangChain/LangGraph agents — are planned but not yet part of the API.
+:::
 
 ## Creating an Agent
 
@@ -74,40 +62,23 @@ For Eliza agents:
 5. Click **Deploy**
 -->
 
-::: code-group
-
-```bash [CLI]
-# Create an Eliza agent
-acc agents create --name "My Agent" --type eliza --character ./character.json
-
-# List agents
-acc agents list
-
-# Get agent status
-acc agents status <agent-id>
-```
-
-```typescript [SDK]
-import { AlternateFuturesSdk, PersonalAccessTokenService } from '@alternatefutures/sdk/node';
-
-const af = new AlternateFuturesSdk({
-  accessTokenService: new PersonalAccessTokenService({
-    personalAccessToken: '<your-token>',
-    projectId: '<your-project-id>',
-  }),
-});
-
-// Create an agent
-const agent = await af.agents().create({
-  name: 'My Agent',
-  type: 'eliza',
-  config: {
-    // Agent configuration
+```graphql
+mutation {
+  createAgent(input: {
+    name: "Support Assistant"
+    slug: "support-assistant"
+    description: "Answers product questions"
+    systemPrompt: "You are a helpful support agent for Alternate Clouds."
+    model: "claude-sonnet"
+    # functionId: "<optional-function-id>"
+  }) {
+    id
+    name
+    slug
+    status
   }
-});
+}
 ```
-
-:::
 
 ## Managing Agents
 
@@ -130,36 +101,24 @@ Each agent will have a dashboard showing:
 - **Delete** - Remove agent permanently
 -->
 
-::: code-group
+Start a chat and send a message, then delete the chat when you're done:
 
-```bash [CLI]
-# Start an agent
-acc agents start <agent-id>
+```graphql
+mutation {
+  createChat(agentId: "<agent-id>") { id }
+}
 
-# Stop an agent
-acc agents stop <agent-id>
+mutation {
+  sendMessage(chatId: "<chat-id>", content: "Hello!") { id role content }
+}
 
-# View logs
-acc agents logs <agent-id>
-
-# Delete an agent
-acc agents delete <agent-id>
+mutation {
+  deleteChat(chatId: "<chat-id>") { id }
+}
 ```
 
-```typescript [SDK]
-// Start an agent
-await af.agents().start(agentId);
-
-// Stop an agent
-await af.agents().stop(agentId);
-
-// Get logs
-const logs = await af.agents().logs(agentId);
-
-// Delete an agent
-await af.agents().delete(agentId);
-```
-
+::: info Roadmap
+There is no start/stop/logs lifecycle for agents today — an agent is available as soon as it is created.
 :::
 
 ## Agent Configuration
@@ -187,46 +146,7 @@ DISCORD_BOT_TOKEN=...
 TWITTER_API_KEY=...
 ```
 
-#### Using CLI Flags
-
-Pass environment variables directly when creating or updating agents:
-
-::: code-group
-
-```bash [CLI]
-# Set variables during agent creation
-acc agents create \
-  --name "My Agent" \
-  --type eliza \
-  --env OPENAI_API_KEY=sk-... \
-  --env MODEL=gpt-4
-
-# Update existing agent variables
-acc agents update <agent-id> \
-  --env TEMPERATURE=0.8
-```
-
-```typescript [SDK]
-// Set variables during agent creation
-const agent = await af.agents().create({
-  name: 'My Agent',
-  type: 'eliza',
-  env: {
-    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
-    MODEL: 'gpt-4',
-    TEMPERATURE: '0.7'
-  }
-});
-
-// Update existing agent variables
-await af.agents().update(agentId, {
-  env: {
-    TEMPERATURE: '0.8'
-  }
-});
-```
-
-:::
+<!-- Removed: `acc agents ... --env` and `af.agents().create({ env })` — the agents CLI command, the agents() SDK client, and env/type/character fields on the agent model do not exist. -->
 
 #### Using Character Files
 
@@ -258,22 +178,9 @@ For Eliza agents, include environment variables in your `character.json`:
 Environment variables are stored securely and encrypted at rest. However, they will be accessible to your running agent, so only use trusted code.
 :::
 
-### Platform Integrations
-
-Connect agents to:
-
-- **Discord** - Bot token and permissions
-- **Twitter** - OAuth credentials
-- **Telegram** - Bot token
-- **Slack** - Webhook URL
-
-### Memory Settings
-
-Configure agent memory:
-
-- **Short-term** - Conversation context
-- **Long-term** - Persistent knowledge
-- **Vector DB** - Embeddings storage
+::: info Roadmap
+Platform integrations (Discord, Twitter, Telegram, Slack) and configurable memory (short-term, long-term, vector DB) are planned but not represented in the current agent schema.
+:::
 
 ## Next Steps
 

--- a/docs/guides/api-keys.md
+++ b/docs/guides/api-keys.md
@@ -23,7 +23,11 @@ Generate and manage API keys for programmatic access to Alternate Futures.
 
 ## Permissions
 
-API keys support granular permissions:
+::: info Roadmap
+Scoped permissions are not yet implemented. Token creation currently accepts only a name, organization, and optional expiration — a token has the same access as its owner. The scopes below describe the planned model.
+:::
+
+Planned granular permissions:
 
 ### Read Permissions
 
@@ -50,9 +54,9 @@ API keys support granular permissions:
 Set as environment variables:
 
 ```bash
-export AF_TOKEN="pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-export AF_PROJECT_ID="prj_xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-acc sites list
+export AF_TOKEN="af_live_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+export AF_PROJECT_ID="clx1a2b3c4d5e6f7g8h9"
+acc projects list
 ```
 
 ### SDK
@@ -81,10 +85,24 @@ Include in Authorization header:
 
 ```bash
 curl https://api.alternatefutures.ai/graphql \
-  -H "Authorization: Bearer pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
+  -H "Authorization: Bearer af_live_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
   -H "Content-Type: application/json" \
   -d '{"query": "{ sites { id name } }"}'
 ```
+
+## Managing keys via CLI
+
+Personal access tokens can be managed with the (currently hidden) `pat` command:
+
+```bash
+acc pat list
+acc pat create --name "Production CI"
+acc pat delete <token-id>
+```
+
+::: tip What this maps to in code
+See the [pat CLI command](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/pat/index.ts). `create` takes only `--name`; there are no `--expires` or `--permissions` flags yet.
+:::
 
 ## Managing API Keys
 
@@ -141,33 +159,27 @@ Deleted keys are removed from all logs and cannot be recovered.
 
 ## Key Formats
 
-Personal Access Tokens follow this format:
+Personal access tokens follow this format:
 
 ```
-pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+af_live_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx   # production
+af_test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx   # test
 ```
 
-- Prefix: `pat_` (Personal Access Token)
-- Length: 36 characters total (4 char prefix + 32 char random string)
-- Characters: Base62 encoded (a-z, A-Z, 0-9)
+- Prefix: `af_live_` or `af_test_` (the `af` prefix plus an environment segment)
+- Random segment: 32 characters, Base62 (a-z, A-Z, 0-9)
 
-Project IDs follow this format:
+::: tip What this maps to in code
+The format is defined by the [token service](https://github.com/alternatefutures/service-auth/blob/main/src/services/token.service.ts) — `af_${environment}_${base62}`.
+:::
 
-```
-prj_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-```
+Project IDs are [cuid](https://github.com/paralleldrive/cuid) values (for example `clx1a2b3c4d5e6f7g8h9`); there is no `prj_` prefix.
 
 ## Rate Limits
 
 ### API Request Limits
 
-API keys are subject to rate limits based on your plan:
-
-- **Free tier**: 100 requests/minute
-- **Pro tier**: 1,000 requests/minute
-- **Enterprise**: Custom limits
-
-Exceeded rate limits return HTTP 429 (Too Many Requests).
+API requests are rate limited, and limits scale with your plan (Free < Pro < Enterprise). Exceeded limits return HTTP 429 (Too Many Requests). Specific per-plan request rates are set by your plan — check your account for current values.
 
 ### API Key Creation Limits
 
@@ -204,7 +216,7 @@ If you have 500 active keys:
 **Tips to manage your keys:**
 - Delete unused or expired keys to stay organized
 - Use expiration dates for temporary access
-- Monitor your limits via the GraphQL API:
+- Monitor your limits via the [`apiKeyRateLimit` query](https://github.com/alternatefutures/service-cloud-api/blob/main/src/schema/typeDefs.ts):
   ```graphql
   query {
     apiKeyRateLimit {

--- a/docs/guides/applications.md
+++ b/docs/guides/applications.md
@@ -14,24 +14,27 @@ Applications are OAuth 2.0 applications that can authenticate users and access t
 - **Name** - Human-readable application name
 - **Whitelist Domains** - Allowed domains for CORS and OAuth redirects
 
+::: info What this maps to in code
+- **SDK:** [applications client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/applications.ts) — `create({ name, whitelistDomains }) → clientId`, `list`, `update`, `delete`.
+- **API:** [`Application` GraphQL type](https://github.com/alternatefutures/service-cloud-api/blob/main/src/schema/typeDefs.ts) — `clientId`, `whitelistDomains`.
+:::
+
+::: tip CLI
+There is no `acc applications` command. Applications are managed entirely through the **SDK / GraphQL API**. The examples below use the SDK.
+:::
+
 ## Creating an Application
 
 ::: code-group
 
-```bash [CLI]
-# Create a new application
-acc applications create
-
-# You'll be prompted for:
-# - Application name
-# - Whitelist domains (comma-separated)
-```
-
 ```typescript [SDK]
-import { AlternateFuturesSdk } from '@alternatefutures/sdk/node';
+import { AlternateFuturesSdk, PersonalAccessTokenService } from '@alternatefutures/sdk/node';
 
 const af = new AlternateFuturesSdk({
-  personalAccessToken: process.env.AF_TOKEN
+  accessTokenService: new PersonalAccessTokenService({
+    personalAccessToken: process.env.AF_TOKEN,
+    projectId: process.env.AF_PROJECT_ID,
+  }),
 });
 
 // Create an application
@@ -49,11 +52,6 @@ console.log('Client ID:', app.clientId);
 
 ::: code-group
 
-```bash [CLI]
-# List all applications
-acc applications list
-```
-
 ```typescript [SDK]
 // List all applications
 const applications = await af.applications().list();
@@ -70,15 +68,6 @@ applications.forEach(app => {
 
 ::: code-group
 
-```bash [CLI]
-# Update an application
-acc applications update
-
-# You'll be prompted to:
-# 1. Select the application
-# 2. Update name and/or whitelist domains
-```
-
 ```typescript [SDK]
 // Update application
 await af.applications().update({
@@ -93,13 +82,6 @@ await af.applications().update({
 ## Deleting an Application
 
 ::: code-group
-
-```bash [CLI]
-# Delete an application
-acc applications delete
-
-# You'll be prompted to select which application to delete
-```
 
 ```typescript [SDK]
 // Delete an application
@@ -119,12 +101,15 @@ Use applications to authenticate users in your web application:
 3. Users can sign in with their Alternate Futures account
 4. Your application receives an access token to make API calls
 
-### CORS Configuration
+::: info
+The application record (Client ID and whitelisted domains) is available today. Confirm which parts of the end-to-end OAuth authorization flow are live before building against it.
+:::
 
-Whitelist domains are automatically allowed for CORS requests:
+### CORS and whitelisted domains
+
+Whitelisted domains are stored on the application record and are intended to control which origins may use it:
 
 ```typescript
-// This request will succeed if the origin is whitelisted
 fetch('https://api.alternatefutures.ai/v1/sites', {
   headers: {
     'Authorization': `Bearer ${accessToken}`
@@ -132,20 +117,26 @@ fetch('https://api.alternatefutures.ai/v1/sites', {
 });
 ```
 
+::: warning
+Confirm the current CORS behavior for `api.alternatefutures.ai` before relying on it in production — enforcement details may change.
+:::
+
 ### Multi-Environment Setup
 
-Create separate applications for different environments:
+Create separate applications for different environments via the SDK:
 
-```bash
-# Development app
-acc applications create
-# Name: My App (Dev)
-# Domains: http://localhost:3000
+```typescript
+// Development app
+await af.applications().create({
+  name: 'My App (Dev)',
+  whitelistDomains: ['http://localhost:3000']
+});
 
-# Production app
-acc applications create
-# Name: My App (Prod)
-# Domains: https://myapp.com, https://www.myapp.com
+// Production app
+await af.applications().create({
+  name: 'My App (Prod)',
+  whitelistDomains: ['https://myapp.com', 'https://www.myapp.com']
+});
 ```
 
 ## Security Best Practices

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -16,36 +16,47 @@ Passwordless authentication via email:
 2. Check your inbox for the magic link
 3. Click the link to sign in
 
-### SMS Magic Link
+### SMS OTP
 
-Passwordless authentication via SMS:
+Passwordless authentication via a one-time code:
 
 1. Enter your phone number
-2. Receive a text message with the link
-3. Click the link to sign in
+2. Receive a 6-digit code by text
+3. Enter the code to sign in
+
+::: tip What this maps to in code
+See the [SMS OTP endpoint](https://github.com/alternatefutures/service-auth/blob/main/src/routes/auth/sms.ts) — it generates a 6-digit code and verifies it at `/auth/sms/verify`.
+:::
 
 ### Web3 Wallets
 
-Sign in with your cryptocurrency wallet:
+Sign in with an Ethereum wallet using the "Sign in with Ethereum" (SIWE) standard:
 
-- **MetaMask** - Ethereum wallet
-- **Phantom** - Solana wallet
-- **WalletConnect** - Universal wallet connection
-- **Coinbase Wallet**
-- **Rainbow Wallet**
+- **MetaMask**
+- **WalletConnect**
 
-Uses "Sign in with Ethereum" (SIWE) standard for secure authentication.
+Other EVM-compatible wallets (Coinbase Wallet, Rainbow) generally work through the same SIWE flow.
+
+::: info Solana not yet supported
+Solana wallets (including Phantom) are not currently supported — the wallet flow rejects Solana addresses and asks you to use an Ethereum wallet.
+:::
+
+::: tip What this maps to in code
+See the [Web3 wallet (SIWE) handler](https://github.com/alternatefutures/service-auth/blob/main/src/routes/auth/wallet.ts).
+:::
 
 ### Social OAuth
 
-Sign in with your existing accounts:
+Sign in with an existing account:
 
 - **Google**
-- **Apple**
-- **Twitter**
-- **Discord**
 - **GitHub**
-- **Facebook**
+- **Twitter/X**
+- **Discord**
+
+::: tip What this maps to in code
+Providers are registered in the [OAuth provider configuration](https://github.com/alternatefutures/service-auth/blob/main/src/services/oauth.service.ts). Apple Sign In is temporarily disabled; Facebook is not yet available.
+:::
 
 ## Account Linking
 
@@ -81,9 +92,9 @@ API key management via the web interface is currently in development. In the mea
 
 **CLI:**
 ```bash
-export AF_TOKEN="your-personal-access-token"
+export AF_TOKEN="af_live_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 export AF_PROJECT_ID="your-project-id"
-acc sites list
+acc projects list
 ```
 
 **SDK:**

--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -147,19 +147,10 @@ module.exports = {
 
 ### Storage Costs
 
-**Unpin Unused Content (IPFS):**
-```bash
-# List all pinned content
-acc storage list --network ipfs --pinned
-
-# Unpin old deployments
-acc storage unpin QmOldCID
-```
-
-**Use Filecoin for Archives:**
-```bash
-# Move old content from IPFS to Filecoin
-acc storage migrate QmXxx --from ipfs --to filecoin
+**Unpin unused content (IPFS):** there is no `acc storage` command; manage pins through the SDK.
+```typescript
+const items = await af.storage().list();
+await af.ipfs().unpin('QmOldCID');
 ```
 
 **Compress Before Upload:**
@@ -167,8 +158,8 @@ acc storage migrate QmXxx --from ipfs --to filecoin
 # Create compressed archive
 tar -czf site.tar.gz dist/
 
-# Deploy compressed (auto-extracted)
-acc sites deploy site.tar.gz
+# Deploy the project's service
+acc services deploy
 ```
 
 ### Bandwidth Costs
@@ -189,19 +180,7 @@ acc sites deploy site.tar.gz
 
 ### Compute Costs
 
-**Agent Optimization:**
-```javascript
-// Stop agents when not needed
-acc agents stop agent-id
-
-// Start on-demand
-acc agents start agent-id
-
-// Use smaller models
-{
-  model: "gpt-3.5-turbo"  // vs gpt-4
-}
-```
+**Agent Optimization:** choose a smaller/cheaper model when full capability isn't needed — set `model` on the agent to a lighter option.
 
 ## Security Best Practices
 
@@ -209,18 +188,19 @@ acc agents start agent-id
 
 ```bash
 # Use environment variables
-export AF_TOKEN="af_pat_xxx"
+export AF_TOKEN="af_live_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 # Never commit to git
 echo "AF_TOKEN=*" >> .gitignore
 
-# Rotate regularly
-acc api-keys create --expires 90d
-acc api-keys revoke old-key-id
-
-# Use minimal permissions
-acc api-keys create --permissions agents:read,sites:write
+# Rotate regularly (personal access tokens)
+acc pat create --name "ci-2026-q3"
+acc pat delete <old-token-id>
 ```
+
+::: info
+Scoped permissions and expiry flags are not yet available on `acc pat create` (it takes only `--name`).
+:::
 
 ### Content Security
 
@@ -231,51 +211,25 @@ ipfs add --only-hash file.txt
 # Compare with retrieved CID
 ```
 
-**Sign Deployments:**
-```bash
-# Sign with private key for verification
-acc sites deploy ./dist --sign
-```
+<!-- Removed: `acc sites deploy --sign` — deployment signing is not implemented in the CLI. -->
 
 ## Reliability Best Practices
 
 ### Redundancy
 
-**Pin on Multiple Services:**
-```bash
-# Primary pinning service
-acc storage pin QmXxx --provider pinata
+**Pin on multiple services:** manage pins through the SDK (`af.ipfs()` / `af.storage()`). Provider selection at pin time is not exposed through the CLI.
 
-# Backup pinning
-acc storage pin QmXxx --provider web3storage
-```
-
-**Use Multiple Networks:**
-```bash
-# Deploy to both IPFS and Arweave
-acc sites deploy ./dist --network ipfs
-acc sites deploy ./dist --network arweave
-```
+<!-- Removed: `acc sites deploy --network` — there is no sites command or --network flag. -->
 
 ### Monitoring
 
-**Set Up Alerts:**
+**Check deployment health:**
 ```bash
-# Monitor agent uptime
-acc agents monitor agent-id --alert-email you@example.com
-
-# Monitor bandwidth usage
-acc billing alert --type bandwidth --threshold 1TB
-```
-
-**Check Deployment Health:**
-```bash
-# Verify site accessibility
+# Verify accessibility via a gateway
 curl -I https://gateway.ipfs.io/ipfs/QmXxx
-
-# Check all gateways
-acc sites check site-id --all-gateways
 ```
+
+<!-- Removed: `acc agents monitor`, `acc billing alert`, `acc sites check` — none of these commands exist. -->
 
 ## Development Workflow
 
@@ -285,14 +239,11 @@ acc sites check site-id --all-gateways
 # Use local IPFS node
 ipfs daemon
 
-# Test locally before deploying
-acc sites preview ./dist --local
+# Deploy your staging project first
+AF_PROJECT_ID=$STAGING_PROJECT_ID acc services deploy
 
-# Deploy to staging first
-acc sites deploy ./dist --name staging
-
-# Test thoroughly, then deploy to production
-acc sites deploy ./dist --name production
+# Test thoroughly, then deploy production
+AF_PROJECT_ID=$PROD_PROJECT_ID acc services deploy
 ```
 
 ### CI/CD
@@ -301,11 +252,15 @@ acc sites deploy ./dist --name production
 # .github/workflows/deploy.yml
 - name: Deploy to staging
   if: github.ref == 'refs/heads/staging'
-  run: acc sites deploy ./dist --network ipfs
+  run: acc services deploy
+  env:
+    AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID_STAGING }}
 
 - name: Deploy to production
   if: github.ref == 'refs/heads/main'
-  run: acc sites deploy ./dist --network arweave
+  run: acc services deploy
+  env:
+    AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID_PROD }}
 ```
 
 ## Content Organization
@@ -313,16 +268,12 @@ acc sites deploy ./dist --name production
 ### Naming Conventions
 
 ```bash
-# Use descriptive names
-acc sites deploy ./dist --name "marketing-website-prod"
-acc agents create --name "discord-bot-support"
-
-# Include version numbers
-acc sites deploy ./dist --name "app-v1.2.0"
-
-# Use tags for organization
-acc sites deploy ./dist --tags production,public
+# Name projects and services descriptively in the dashboard,
+# then deploy the selected project's service:
+acc services deploy
 ```
+
+<!-- Removed: --name/--tags flags and `acc agents create` — not implemented in the CLI. -->
 
 ### Project Structure
 
@@ -331,9 +282,11 @@ my-project/
 ├── dist/              # Built static files
 ├── .env              # API keys (not in git!)
 ├── .gitignore        # Include .env
-├── af.config.json    # Alternate Futures config
+├── af.config.json    # Alternate Clouds config
 └── deploy.sh         # Deployment script
 ```
+
+The CLI resolves configuration in order `af.config.ts` > `af.config.js` > `af.config.json` — see [getConfiguration.ts](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/getConfiguration.ts).
 
 ## Next Steps
 

--- a/docs/guides/billing.md
+++ b/docs/guides/billing.md
@@ -22,64 +22,26 @@ View your billing information at [app.alternatefutures.ai/billing](https://app.a
 
 ## CLI Commands
 
-Manage billing directly from the command line:
-
-### View Customer Information
+The CLI currently exposes a single billing subcommand — your credit balance:
 
 ```bash
-acc billing customer
+acc billing balance
 ```
 
-View your customer details including email, Stripe ID, and account status.
+::: tip What this maps to in code
+`balance` is the only subcommand defined in the [billing CLI command](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/billing/index.ts). Customer, invoice, subscription, usage, and payment-method operations are available through the SDK's [billing client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/billing.ts) (`af.billing().getCustomer()`, `listInvoices()`, `listSubscriptions()`, `getCurrentUsage()`, `listPaymentMethods()`) — CLI coverage is on the roadmap.
+:::
 
-### List Invoices
+### Invoices, subscriptions, usage, and payment methods (SDK)
 
-```bash
-acc billing invoices
+```typescript
+const invoices = await af.billing().listInvoices();
+const subscriptions = await af.billing().listSubscriptions();
+const usage = await af.billing().getCurrentUsage();
+const methods = await af.billing().listPaymentMethods();
 ```
 
-View all invoices with their status, amounts, and payment details. Invoices include:
-- Invoice number and status
-- Amount due and paid
-- Period covered
-- PDF download link
-
-### View Subscriptions
-
-```bash
-acc billing subscriptions
-```
-
-See your active subscriptions including:
-- Plan type (FREE, STARTER, PRO, ENTERPRISE)
-- Number of seats
-- Pricing details
-- Current period dates
-- Cancellation status
-
-### Check Usage
-
-```bash
-acc billing usage
-```
-
-View current billing cycle usage:
-- **Storage** - GB stored and costs
-- **Bandwidth** - Data transfer and costs
-- **Compute** - Processing time and costs
-- **Requests** - API calls and costs
-- **Total** - Current period total
-
-### Manage Payment Methods
-
-```bash
-acc billing payment-methods
-```
-
-List all payment methods on file including:
-- Credit/debit cards (last 4 digits, expiration)
-- Cryptocurrency wallets
-- Default payment method
+Each returns the same data the dashboard shows: invoice status/amounts/PDF links, plan and seat details, current-cycle usage, and payment methods on file.
 
 ## Usage Tracking
 
@@ -119,32 +81,31 @@ Track agent and function execution:
 | Filecoin | Per GB/month | ~$0.03 |
 | Arweave | One-time per GB | ~$6.00 |
 
+::: warning Illustrative rates
+The bandwidth and compute figures below are examples for planning, not committed prices. Billing is plan- and Stripe-driven; confirm current rates for your account.
+:::
+
 ### Bandwidth Costs
 
 | Tier | Included | Overage |
 |------|----------|---------|
-| Free | 100 GB | $0.10/GB |
-| Pro | 1 TB | $0.08/GB |
+| Free | 100 GB | ~$0.10/GB |
+| Pro | 1 TB | ~$0.08/GB |
 | Enterprise | Custom | Custom |
 
 ### Compute Costs
 
-| Service | Price |
+| Service | Example rate |
 |---------|-------|
-| Agent Runtime | $0.05/hour |
-| Function Invocations | $0.20/million |
-| GPU Processing | $0.50/hour |
+| Agent Runtime | ~$0.05/hour |
+| Function Invocations | ~$0.20/million |
+| GPU Processing | ~$0.50/hour |
 
 ## Payment Methods
 
 ### Cryptocurrency
 
-Pay with crypto (preferred):
-
-- **AR** (Arweave) - Native token
-- **FIL** (Filecoin) - Storage token
-- **ETH** (Ethereum) - Universal payment
-- **SOL** (Solana) - Fast payments
+Pay with crypto. Payments settle to a deposit address by `chainId` and `tokenSymbol` (default **USDC**); additional tokens and chains are added over time. Confirm supported tokens at checkout.
 
 **Benefits:**
 - Lower fees (no credit card processing)

--- a/docs/guides/cicd.md
+++ b/docs/guides/cicd.md
@@ -36,10 +36,11 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Deploy to Alternate Futures
-        run: npx @alternatefutures/cli sites deploy ./dist --network ipfs
+      - name: Deploy to Alternate Clouds
+        run: npx @alternatefutures/cli services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN }}
+          AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID }}
 ```
 
 ### Add API Key Secret
@@ -79,15 +80,17 @@ jobs:
 
       - name: Deploy to Staging
         if: github.ref == 'refs/heads/staging'
-        run: npx @alternatefutures/cli sites deploy ./dist --network ipfs --name staging
+        run: npx @alternatefutures/cli services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN_STAGING }}
+          AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID_STAGING }}
 
       - name: Deploy to Production
         if: github.ref == 'refs/heads/main'
-        run: npx @alternatefutures/cli sites deploy ./dist --network arweave --name production
+        run: npx @alternatefutures/cli services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN_PROD }}
+          AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID_PROD }}
 ```
 
 ## GitLab CI/CD
@@ -121,9 +124,10 @@ deploy:
     - main
   script:
     - npm install -g @alternatefutures/cli
-    - acc sites deploy ./dist --network ipfs
+    - acc services deploy
   variables:
     AF_TOKEN: $AF_TOKEN
+    AF_PROJECT_ID: $AF_PROJECT_ID
 ```
 
 Add `AF_TOKEN` in GitLab project settings:
@@ -164,7 +168,7 @@ jobs:
           name: Deploy
           command: |
             npm install -g @alternatefutures/cli
-            acc sites deploy ./dist --network ipfs
+            acc services deploy
 
 workflows:
   deploy:
@@ -197,7 +201,7 @@ Then add deployment hook:
 {
   "scripts": {
     "vercel-build": "npm run build && npm run deploy:af",
-    "deploy:af": "npx @alternatefutures/cli sites deploy ./dist --network ipfs"
+    "deploy:af": "npx @alternatefutures/cli services deploy"
   }
 }
 ```
@@ -235,7 +239,7 @@ pipeline {
             }
             steps {
                 sh 'npm install -g @alternatefutures/cli'
-                sh 'acc sites deploy ./dist --network ipfs'
+                sh 'acc services deploy'
             }
         }
     }
@@ -244,34 +248,31 @@ pipeline {
 
 Add `af-token` credential in Jenkins credentials manager.
 
-## CLI Options
+## The deploy command
 
-Common deployment options:
+Deployments run through `services deploy`, scoped to a project:
 
 ```bash
-# Deploy with custom name
-acc sites deploy ./dist --name "My Site" --network ipfs
+# Deploy the current project's service
+acc services deploy
 
-# Deploy with metadata
-acc sites deploy ./dist --description "Production v1.2.0"
-
-# Deploy to specific network
-acc sites deploy ./dist --network arweave  # or ipfs, filecoin
-
-# Wait for deployment completion
-acc sites deploy ./dist --wait
-
-# Get deployment URL in JSON
-acc sites deploy ./dist --json | jq -r '.url'
+# Target a specific service by id
+acc services deploy <service-id>
 ```
+
+::: tip What this maps to in code
+See the [services deploy command](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/services/index.ts). It reads `AF_TOKEN`, `AF_PROJECT_ID`, and `AF_ORG_ID` from the environment ([secrets.ts](https://github.com/alternatefutures/cloud-cli/blob/main/src/secrets.ts)). Flags such as `--name`, `--network`, `--wait`, and `--json` are not implemented.
+:::
 
 ## Environment Variables
 
-CLI reads these environment variables:
+The CLI reads these environment variables:
 
-- `AF_TOKEN` - API key for authentication
-- `AF_SITE_ID` - Default site ID (optional)
-- `AF_NETWORK` - Default network (optional)
+- `AF_TOKEN` - personal access token for authentication
+- `AF_PROJECT_ID` - default project id
+- `AF_ORG_ID` - default organization id
+
+See [secrets.ts](https://github.com/alternatefutures/cloud-cli/blob/main/src/secrets.ts).
 
 ## Best Practices
 
@@ -295,7 +296,6 @@ CLI reads these environment variables:
 
 - ✅ Add status checks before deploying
 - ✅ Run tests before deployment
-- ✅ Use `--wait` flag for deployment confirmation
 - ✅ Monitor deployment success/failure
 - ✅ Set up notifications for failed deployments
 

--- a/docs/guides/custom-domains.md
+++ b/docs/guides/custom-domains.md
@@ -4,7 +4,7 @@ description: Connect custom domains from any registrar to your Alternate Futures
 
 # Custom Domains
 
-Bring your own domain from any registrar (GoDaddy, Namecheap, Cloudflare, etc.) and point it to your AlternateFutures site.
+Bring your own domain from any registrar (GoDaddy, Namecheap, Cloudflare, etc.) and point it to your Alternate Futures site.
 
 ## Overview
 
@@ -20,6 +20,12 @@ Custom domains provide:
 - SEO benefits
 - Professional appearance
 - Automatic SSL/TLS certificates via Let's Encrypt
+
+::: tip What this maps to in code
+- SDK methods live in the [`domains.ts` client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/domains.ts) (`createCustomDomain`, `verifyCustomDomain`, `provisionSsl`, `setPrimaryDomain`, `removeCustomDomain`).
+- The authoritative GraphQL surface (Domain type, mutations, `CreateDomainInput`) is in [`typeDefs.ts`](https://github.com/alternatefutures/service-cloud-api/blob/main/src/schema/typeDefs.ts).
+- Verification and SSL status fields are backed by the [Prisma `Domain` model](https://github.com/alternatefutures/service-cloud-api/blob/main/prisma/schema.prisma).
+:::
 
 ## Adding a Custom Domain
 
@@ -46,9 +52,10 @@ const af = new AlternateFuturesSdk({
 });
 
 // Add a custom domain
-const domain = await af.domains().create({
+const domain = await af.domains().createCustomDomain({
   siteId: 'site_abc123',
   hostname: 'example.com',
+  verificationMethod: 'TXT',
 });
 
 console.log('Domain created:', domain.hostname);
@@ -60,7 +67,7 @@ mutation {
   createDomain(input: {
     hostname: "example.com"
     siteId: "site-123"
-    verificationMethod: TXT
+    verificationMethod: "TXT"
   }) {
     id
     hostname
@@ -100,7 +107,7 @@ mutation {
   createDomain(input: {
     hostname: "example.com"
     siteId: "site-123"
-    verificationMethod: TXT
+    verificationMethod: "TXT"
   }) {
     id
     txtVerificationToken  # Use this value
@@ -132,10 +139,10 @@ mutation {
   createDomain(input: {
     hostname: "www.example.com"
     siteId: "site-123"
-    verificationMethod: CNAME
+    verificationMethod: "CNAME"
   }) {
     id
-    expectedCname  # Points to platform
+    dnsConfigs  # Contains the CNAME target to set at your registrar
   }
 }
 ```
@@ -167,10 +174,10 @@ mutation {
   createDomain(input: {
     hostname: "example.com"
     siteId: "site-123"
-    verificationMethod: A
+    verificationMethod: "A"
   }) {
     id
-    expectedARecord  # Platform IP
+    dnsConfigs  # Contains the A-record target IP to set at your registrar
   }
 }
 ```
@@ -198,7 +205,7 @@ acc domains detail --hostname example.com
 
 ```typescript [SDK]
 // Verify DNS configuration
-const verified = await af.domains().verify({ id: domain.id });
+const verified = await af.domains().verifyCustomDomain({ domainId: domain.id });
 console.log('Verified:', verified);
 ```
 
@@ -306,15 +313,8 @@ Set a verified domain as the primary domain for your site:
 
 ```graphql
 mutation {
-  setPrimaryDomain(
-    siteId: "site-123"
-    domainId: "domain-123"
-  ) {
-    id
-    primaryDomain {
-      hostname
-    }
-  }
+  # setPrimaryDomain returns Boolean!
+  setPrimaryDomain(siteId: "site-123", domainId: "domain-123")
 }
 ```
 
@@ -328,7 +328,7 @@ Remove a custom domain:
 
 ```graphql
 mutation {
-  removeDomain(domainId: "domain-123")
+  deleteDomain(id: "domain-123")
 }
 ```
 
@@ -454,17 +454,17 @@ openssl s_client -connect example.com:443 -servername example.com
 
 ## Supported DNS Providers
 
-Tested and working with:
+Custom domains work with any DNS provider that supports standard TXT, CNAME, and A records, including:
 
-- **Cloudflare** - Fast propagation (5-15 min), excellent DNS management
-- **Namecheap** - Good propagation (30-60 min)
-- **GoDaddy** - Slower propagation (2-24 hours)
-- **Google Domains** - Fast and reliable
-- **AWS Route53** - Enterprise-grade, fast propagation
-- **DigitalOcean DNS** - Fast and simple
-- **Vercel DNS** - Fast propagation
+- **Cloudflare**
+- **Namecheap**
+- **GoDaddy**
+- **Google Domains / Cloud DNS**
+- **AWS Route53**
+- **DigitalOcean DNS**
+- **Vercel DNS**
 
-All major DNS providers support TXT, CNAME, and A records needed for domain verification.
+Propagation time depends entirely on your provider and the TTL you set — it can range from a few minutes to several hours. All major providers support the TXT, CNAME, and A records needed for domain verification.
 
 ## Web3 Domains
 
@@ -474,13 +474,13 @@ Register permanent domains on Arweave:
 
 ```graphql
 mutation {
-  registerArnsName(
-    siteId: "site-123"
+  registerArns(
+    domainId: "domain-123"
     arnsName: "my-site"
+    contentId: "<ipfs-or-arweave-content-id>"
   ) {
-    name
-    transactionId
-    contentId
+    id
+    arnsName
   }
 }
 ```
@@ -492,20 +492,7 @@ mutation {
 
 ### ENS (Ethereum Name System)
 
-Link ENS domains to your content:
-
-```graphql
-mutation {
-  linkEnsDomain(
-    siteId: "site-123"
-    ensName: "mysite.eth"
-  ) {
-    ensName
-    contentHash
-    resolverAddress
-  }
-}
-```
+Link ENS domains to your content using the SDK's ENS client. See the dedicated [ENS guide](./ens.md) for the full flow (`af.ens().create(...)`, setting the content hash, and verification).
 
 **Features:**
 - Ethereum-based domain names
@@ -514,20 +501,7 @@ mutation {
 
 ### IPNS (IPFS Name System)
 
-Create mutable IPNS pointers:
-
-```graphql
-mutation {
-  createIpnsName(
-    siteId: "site-123"
-    ipnsName: "my-ipns-site"
-  ) {
-    ipnsName
-    ipnsHash
-    currentCid
-  }
-}
-```
+Create mutable IPNS pointers using the SDK's IPNS client. See the [IPNS guide](./ipns.md) for `af.ipns().createRecordForSite(...)` and publishing updates.
 
 **Features:**
 - Mutable pointers to IPFS content
@@ -544,7 +518,7 @@ mutation CreateDomain {
   createDomain(input: {
     hostname: "example.com"
     siteId: "site-abc123"
-    verificationMethod: TXT
+    verificationMethod: "TXT"
   }) {
     id
     hostname
@@ -596,17 +570,9 @@ mutation ProvisionSSL {
 # Step 7: Wait 5-10 minutes for Let's Encrypt
 # Your site is now live at https://example.com!
 
-# Step 8: Set as primary domain (optional)
+# Step 8: Set as primary domain (optional) — returns Boolean
 mutation SetPrimary {
-  setPrimaryDomain(
-    siteId: "site-abc123"
-    domainId: "domain-xyz789"
-  ) {
-    id
-    primaryDomain {
-      hostname
-    }
-  }
+  setPrimaryDomain(siteId: "site-abc123", domainId: "domain-xyz789")
 }
 ```
 
@@ -628,10 +594,10 @@ mutation SetPrimary {
 
 **setPrimaryDomain** - Set primary domain for site
 - Input: `siteId: ID!`, `domainId: ID!`
-- Returns: `Site`
+- Returns: `Boolean`
 
-**removeDomain** - Remove custom domain
-- Input: `domainId: ID!`
+**deleteDomain** - Remove custom domain
+- Input: `id: ID!`
 - Returns: `Boolean`
 
 ### Queries
@@ -640,8 +606,8 @@ mutation SetPrimary {
 - Input: `id: ID!`
 - Returns: `Domain`
 
-**domains** - List all domains for a site
-- Input: `siteId: ID!`
+**Site.domains** - List all domains for a site
+- Accessed via the `site(id: ID!) { domains { ... } }` query (there is no top-level `domains` root query)
 - Returns: `[Domain!]!`
 
 ## Next Steps

--- a/docs/guides/dashboard.md
+++ b/docs/guides/dashboard.md
@@ -4,8 +4,8 @@ description: Overview of the Alternate Futures web dashboard for managing agents
 
 # Dashboard Overview
 
-::: warning Web App Under Development
-The Alternate Futures web dashboard is currently under development. For now, please use the [CLI](../cli/) or [SDK](../sdk/) to manage your infrastructure.
+::: warning Web dashboard in development
+The Alternate Clouds web dashboard is in active development. For now, manage your infrastructure with the [CLI](../cli/) (`acc`) or the [SDK](../sdk/).
 :::
 
 <!--
@@ -71,10 +71,10 @@ Bell icon shows:
 - Click on cards/items for detailed views
 -->
 
-## Current Options
+## Manage your infrastructure today
 
-Until the web dashboard is available, you can manage your infrastructure using:
+Until the dashboard ships, use:
 
-- **[CLI Documentation](../cli/)** - Command-line interface for all operations
-- **[SDK Documentation](../sdk/)** - Programmatic API access
-- **[Quick Start Guide](./quickstart.md)** - Get started with CLI/SDK
+- **[CLI](../cli/)** — the `acc` command-line interface for all operations
+- **[SDK](../sdk/)** — programmatic API access
+- **[Quick Start](./quickstart.md)** — get running with the CLI or SDK

--- a/docs/guides/decentralized-registry.md
+++ b/docs/guides/decentralized-registry.md
@@ -4,9 +4,13 @@ description: Store and distribute Docker images on a fully decentralized contain
 
 # Decentralized Container Registry
 
+::: warning Reference architecture — not a hosted service (yet)
+This guide describes a self-hostable reference architecture for running a decentralized container registry (OpenRegistry + IPFS on Akash). It is not currently offered as a managed Alternate Futures service, and the `registry.alternatefutures.ai` / `ipfs.alternatefutures.ai` endpoints, storage limits, and ports shown below are illustrative of a self-hosted deployment rather than a live shared registry. Substitute your own domain and infrastructure values. To stand up the stack yourself, follow [Deploying the Decentralized Registry](/guides/registry-deployment).
+:::
+
 ## Overview
 
-Alternate Futures provides a **fully decentralized container registry** for storing and distributing Docker images. Unlike centralized services like Docker Hub, your container images are stored on your own infrastructure running on Akash Network with IPFS storage.
+The decentralized container registry is a **self-hostable** way to store and distribute Docker images. Unlike centralized services like Docker Hub, your container images are stored on infrastructure you run on Akash Network with IPFS storage.
 
 ## Architecture
 
@@ -40,9 +44,7 @@ registry.alternatefutures.ai  ipfs.alternatefutures.ai
 - **Censorship Resistant**: Images stored on IPFS cannot be taken down
 
 ### Cost Savings
-- **Traditional Stack**: $77-307/month (Docker Hub + IPFS service + cloud hosting)
-- **Decentralized Stack**: $40-70/month (Akash only)
-- **Savings**: 40-85% cost reduction
+Costs depend on your image volume, traffic, and the Akash provider you choose. A self-hosted stack on Akash can be meaningfully cheaper than combining a managed registry, a hosted IPFS service, and cloud compute, but exact figures vary — benchmark against your own workload rather than relying on a fixed estimate.
 
 ### Performance
 - **Global Distribution**: IPFS enables P2P delivery
@@ -146,9 +148,11 @@ All container layers are stored on IPFS with these benefits:
 
 ### IPFS Node Details
 
-- **Storage**: 100GB persistent volume on Akash
-- **API**: Port 5001 (internal only)
-- **Gateway**: Port 8080 (public at `ipfs.alternatefutures.ai`)
+The following are example values for a self-hosted deployment — adjust them to your own SDL and domain:
+
+- **Storage**: e.g. a 100GB persistent volume on Akash
+- **API**: Port 5001 (keep internal only)
+- **Gateway**: Port 8080 (exposed at your own `ipfs.` subdomain)
 - **Swarm**: Port 4001 (P2P connections)
 
 ### Viewing IPFS Content
@@ -165,49 +169,32 @@ https://ipfs.alternatefutures.ai/ipfs/<CID>
 - **Total Storage**: 100GB initially (expandable)
 - **Garbage Collection**: Automatic cleanup of unused layers
 
-## CLI Commands
+## Working with the Registry
 
-### List Images
+There is no dedicated `acc registry` command — the registry is OCI-compliant, so you interact with it using the standard `docker` client.
 
-```bash
-acc registry list
-```
-
-Shows all your container images with:
-- Repository name
-- Tags
-- Size
-- IPFS CIDs
-- Created date
-
-### Image Details
+### List repositories and tags
 
 ```bash
-acc registry info myapp:latest
+# List repositories
+curl https://registry.yourdomain.com/v2/_catalog
+
+# List tags for a repository
+curl https://registry.yourdomain.com/v2/myapp/tags/list
 ```
 
-Displays:
-- Manifest
-- Layer CIDs
-- Total size
-- Build date
-- Digest
-
-### Push Image
+### Push an image
 
 ```bash
-acc registry push myapp:latest
+docker tag myapp:latest registry.yourdomain.com/myapp:latest
+docker push registry.yourdomain.com/myapp:latest
 ```
 
-Tags and pushes to `registry.alternatefutures.ai/myapp:latest`
-
-### Pull Image
+### Pull an image
 
 ```bash
-acc registry pull myapp:latest
+docker pull registry.yourdomain.com/myapp:latest
 ```
-
-Pulls from decentralized registry
 
 ## CI/CD Integration
 
@@ -400,9 +387,9 @@ docker login registry.alternatefutures.ai
 
 **Symptom**: `manifest unknown`
 
-**Solution**: Verify image name and tag
+**Solution**: Verify the image name and tag
 ```bash
-acc registry list  # Check available images
+curl https://registry.yourdomain.com/v2/_catalog  # List available repositories
 ```
 
 ## Next Steps

--- a/docs/guides/deploy-astro.md
+++ b/docs/guides/deploy-astro.md
@@ -4,16 +4,16 @@ description: Step-by-step guide to deploying an Astro site to decentralized infr
 
 # Deploy an Astro Site
 
-Deploy your Astro site to decentralized infrastructure using Alternate Futures. Astro's static-first architecture makes it an excellent fit for decentralized hosting.
+Deploy an Astro site to Alternate Clouds, the decentralized cloud platform from Alternate Futures. Astro ships static HTML by default, so its output maps directly onto IPFS-backed hosting with no server runtime required.
 
 ## Prerequisites
 
 Before you begin, make sure you have:
 
-- **An Alternate Futures account** - [Sign up here](https://app.alternatefutures.ai) (free, no credit card required)
-- **The AF CLI installed** - `npm install -g @alternatefutures/cli`
+- **An Alternate Clouds account** - [Sign up here](https://app.alternatefutures.ai)
+- **The Alternate Clouds CLI (`acc`) installed** - `npm install -g @alternatefutures/cli`
 - **Node.js 18 or later** - [Download here](https://nodejs.org/en/download)
-- **An Astro project** (or we will create one below)
+- **An Astro project** (or create one below)
 
 ## Quick Deploy (Existing Astro Project)
 
@@ -23,15 +23,19 @@ If you already have an Astro project, deploy it in three commands:
 # Build the production output
 npm run build
 
-# Initialize AF configuration
-acc sites init
+# Authenticate (opens a browser)
+acc login
 
-# Deploy to IPFS
-acc sites deploy
+# Deploy the service
+acc services deploy
 ```
 
 ::: tip Output Directory
-Astro outputs to `./dist` by default. When running `acc sites init`, set the output directory to `dist`.
+Astro outputs to `./dist` by default. Set `distDir` to `dist` in your `acc.config` so the CLI uploads the right folder.
+:::
+
+::: info What this maps to in code
+The commands above are the ones the CLI actually registers — see [the CLI's actual command surface](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts) (`login`, `logout`, `projects`, `services`, `deployments`, `ssh`, `billing`). The deploy subcommand lives at `acc services deploy [id]`.
 :::
 
 ## Step 1: Create a New Astro Project
@@ -41,8 +45,8 @@ If you do not have a project yet, start from our template or create one from scr
 ### Option A: Use the AF Template (Recommended)
 
 ```bash
-# Clone the AF-optimized Astro template
-git clone https://github.com/alternatefutures/template-astro my-astro-site
+# Clone the Alternate Clouds Astro template
+git clone https://github.com/alternatefutures/template-cloud-astro my-astro-site
 cd my-astro-site
 
 # Install dependencies
@@ -117,7 +121,7 @@ npm run preview
 
 The build output will be in the `./dist` directory.
 
-## Step 4: Authenticate with AF
+## Step 4: Authenticate with Alternate Clouds
 
 If you have not already authenticated:
 
@@ -132,18 +136,26 @@ export AF_TOKEN=pat_your_token_here
 ## Step 5: Initialize and Deploy
 
 ```bash
-# Initialize AF site configuration
-acc sites init
+Set the build fields in your `acc.config`:
 
-# When prompted, configure:
-#   Site name: my-astro-site
-#   Build command: npm run build
-#   Output directory: dist
-#   Storage network: ipfs (recommended for getting started)
-
-# Deploy to decentralized storage
-acc sites deploy
+```json
+{
+  "slug": "my-astro-site",
+  "buildCommand": "npm run build",
+  "distDir": "dist"
+}
 ```
+
+Then deploy:
+
+```bash
+# Deploy to decentralized storage
+acc services deploy
+```
+
+::: info What this maps to in code
+`slug`, `buildCommand`, and `distDir` are real fields in the [acc.config schema](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts).
+:::
 
 You should see output like:
 
@@ -157,14 +169,7 @@ You should see output like:
 
 ## Step 6: Set Up a Custom Domain (Optional)
 
-Point your own domain to your deployment:
-
-```bash
-# Add a custom domain
-acc domains add my-astro-site.com --site my-astro-site
-```
-
-Then configure your DNS:
+Add your domain from the [Alternate Clouds dashboard](https://app.alternatefutures.ai) under your project's Domains settings, then configure your DNS:
 
 | Record Type | Name | Value |
 |-------------|------|-------|
@@ -257,8 +262,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Deploy to AF
-        run: npx @alternatefutures/cli sites deploy ./dist --network ipfs
+      - name: Deploy to Alternate Clouds
+        run: npx @alternatefutures/cli services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN }}
 ```
@@ -277,12 +282,19 @@ const af = new AlternateFuturesSdk({
     personalAccessToken: process.env.AF_TOKEN,
     projectId: process.env.AF_PROJECT_ID,
   }),
+  // Required — the SDK throws EnvNotSetError if these are unset
+  ipfsStorageApiUrl: process.env.SDK__IPFS__STORAGE_API_URL,
+  uploadProxyApiUrl: process.env.SDK__UPLOAD_PROXY_API_URL,
 });
 
-// Deploy the build output
-const result = await af.ipfs().add('./dist');
-console.log('Deployed! CID:', result.pin.cid);
+// Upload the build directory. addFromPath() returns an array of results.
+const results = await af.ipfs().addFromPath('./dist');
+console.log('Deployed! CID:', results[0].cid);
 ```
+
+::: info What this maps to in code
+Signatures and the `UploadResult` shape (`{ cid, size, path }`) come from [the SDK IPFS client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipfs.ts): `add(file: IpfsFile)` for a single file, `addFromPath(path)` for a directory.
+:::
 
 ## Common Issues
 

--- a/docs/guides/deploy-nextjs.md
+++ b/docs/guides/deploy-nextjs.md
@@ -4,16 +4,16 @@ description: Step-by-step guide to deploying a Next.js application to decentrali
 
 # Deploy a Next.js App
 
-Deploy your Next.js application to decentralized infrastructure using Alternate Futures. This guide covers both static export and server-side rendering configurations.
+Deploy a Next.js app to Alternate Clouds, the decentralized cloud platform from Alternate Futures. Alternate Clouds serves static output, so this guide walks through configuring Next.js for static export and deploying the result.
 
 ## Prerequisites
 
 Before you begin, make sure you have:
 
-- **An Alternate Futures account** - [Sign up here](https://app.alternatefutures.ai) (free, no credit card required)
-- **The AF CLI installed** - `npm install -g @alternatefutures/cli`
+- **An Alternate Clouds account** - [Sign up here](https://app.alternatefutures.ai)
+- **The Alternate Clouds CLI (`acc`) installed** - `npm install -g @alternatefutures/cli`
 - **Node.js 18 or later** - [Download here](https://nodejs.org/en/download)
-- **A Next.js project** (or we will create one below)
+- **A Next.js project** (or create one below)
 
 ## Quick Deploy (Existing Next.js Project)
 
@@ -23,15 +23,19 @@ If you already have a Next.js project, deploy it in three commands:
 # Build the static export
 npm run build
 
-# Initialize AF configuration
-acc sites init
+# Authenticate (opens a browser)
+acc login
 
-# Deploy to IPFS
-acc sites deploy
+# Deploy the service
+acc services deploy
 ```
 
 ::: tip Output Directory
-Next.js static export outputs to `./out` by default. When running `acc sites init`, set the output directory to `out`.
+Next.js static export outputs to `./out` by default. Set `distDir` to `out` in your `acc.config` so the CLI uploads the right folder.
+:::
+
+::: info What this maps to in code
+These are the commands the CLI actually registers — see [the CLI's actual command surface](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts) (`login`, `logout`, `projects`, `services`, `deployments`, `ssh`, `billing`). Deploy lives at `acc services deploy [id]`.
 :::
 
 ## Step 1: Create a New Next.js Project
@@ -41,8 +45,8 @@ If you do not have a project yet, start from our template or create one from scr
 ### Option A: Use the AF Template (Recommended)
 
 ```bash
-# Clone the AF-optimized Next.js template
-git clone https://github.com/alternatefutures/template-nextjs my-nextjs-app
+# Clone the Alternate Clouds Next.js template
+git clone https://github.com/alternatefutures/template-cloud-nextjs my-nextjs-app
 cd my-nextjs-app
 
 # Install dependencies
@@ -125,7 +129,7 @@ This generates your static site in the `./out` directory. You can preview it loc
 npx serve out
 ```
 
-## Step 4: Authenticate with AF
+## Step 4: Authenticate with Alternate Clouds
 
 If you have not already authenticated:
 
@@ -140,18 +144,26 @@ export AF_TOKEN=pat_your_token_here
 ## Step 5: Initialize and Deploy
 
 ```bash
-# Initialize AF site configuration
-acc sites init
+Set the build fields in your `acc.config`:
 
-# When prompted, configure:
-#   Site name: my-nextjs-app
-#   Build command: npm run build
-#   Output directory: out
-#   Storage network: ipfs (recommended for getting started)
-
-# Deploy to decentralized storage
-acc sites deploy
+```json
+{
+  "slug": "my-nextjs-app",
+  "buildCommand": "npm run build",
+  "distDir": "out"
+}
 ```
+
+Then deploy:
+
+```bash
+# Deploy to decentralized storage
+acc services deploy
+```
+
+::: info What this maps to in code
+`slug`, `buildCommand`, and `distDir` are real fields in the [acc.config schema](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts).
+:::
 
 You should see output like:
 
@@ -165,14 +177,7 @@ You should see output like:
 
 ## Step 6: Set Up a Custom Domain (Optional)
 
-Point your own domain to your deployment:
-
-```bash
-# Add a custom domain
-acc domains add my-nextjs-app.com --site my-nextjs-app
-```
-
-Then configure your DNS:
+Add your domain from the [Alternate Clouds dashboard](https://app.alternatefutures.ai) under your project's Domains settings, then configure your DNS:
 
 | Record Type | Name | Value |
 |-------------|------|-------|
@@ -210,8 +215,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Deploy to AF
-        run: npx @alternatefutures/cli sites deploy ./out --network ipfs
+      - name: Deploy to Alternate Clouds
+        run: npx @alternatefutures/cli services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN }}
 ```
@@ -230,12 +235,19 @@ const af = new AlternateFuturesSdk({
     personalAccessToken: process.env.AF_TOKEN,
     projectId: process.env.AF_PROJECT_ID,
   }),
+  // Required — the SDK throws EnvNotSetError if these are unset
+  ipfsStorageApiUrl: process.env.SDK__IPFS__STORAGE_API_URL,
+  uploadProxyApiUrl: process.env.SDK__UPLOAD_PROXY_API_URL,
 });
 
-// Deploy the build output
-const result = await af.ipfs().add('./out');
-console.log('Deployed! CID:', result.pin.cid);
+// Upload the build directory. addFromPath() returns an array of results.
+const results = await af.ipfs().addFromPath('./out');
+console.log('Deployed! CID:', results[0].cid);
 ```
+
+::: info What this maps to in code
+Signatures and the `UploadResult` shape (`{ cid, size, path }`) come from [the SDK IPFS client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipfs.ts): `add(file: IpfsFile)` for a single file, `addFromPath(path)` for a directory.
+:::
 
 ## Common Issues
 

--- a/docs/guides/deploy-react.md
+++ b/docs/guides/deploy-react.md
@@ -4,16 +4,16 @@ description: Step-by-step guide to deploying a React application (Vite or Create
 
 # Deploy a React App
 
-Deploy your React application to decentralized infrastructure using Alternate Futures. This guide covers both Vite-based and Create React App projects.
+Deploy a React app to Alternate Clouds, the decentralized cloud platform from Alternate Futures. This guide covers both Vite and Create React App builds, from local build through custom-domain routing.
 
 ## Prerequisites
 
 Before you begin, make sure you have:
 
-- **An Alternate Futures account** - [Sign up here](https://app.alternatefutures.ai) (free, no credit card required)
-- **The AF CLI installed** - `npm install -g @alternatefutures/cli`
+- **An Alternate Clouds account** - [Sign up here](https://app.alternatefutures.ai)
+- **The Alternate Clouds CLI (`acc`) installed** - `npm install -g @alternatefutures/cli`
 - **Node.js 18 or later** - [Download here](https://nodejs.org/en/download)
-- **A React project** (or we will create one below)
+- **A React project** (or create one below)
 
 ## Quick Deploy (Existing React Project)
 
@@ -25,22 +25,18 @@ If you already have a React project, deploy it in three commands:
 # Build the production bundle
 npm run build
 
-# Initialize AF configuration
-acc sites init
-
-# Deploy to IPFS
-acc sites deploy
+# Authenticate, then deploy
+acc login
+acc services deploy
 ```
 
 ```bash [Create React App]
 # Build the production bundle
 npm run build
 
-# Initialize AF configuration (set output directory to 'build')
-acc sites init
-
-# Deploy to IPFS
-acc sites deploy
+# Authenticate, then deploy (set distDir to 'build' in acc.config)
+acc login
+acc services deploy
 ```
 
 :::
@@ -49,7 +45,7 @@ acc sites deploy
 - **Vite projects** output to `./dist` by default
 - **Create React App projects** output to `./build` by default
 
-Set the correct directory when running `acc sites init`.
+Set `distDir` to the matching folder in your `acc.config` — it is a real field in the [acc.config schema](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts) (alongside `slug` and `buildCommand`).
 :::
 
 ## Step 1: Create a New React Project
@@ -59,8 +55,8 @@ If you do not have a project yet, start from our template or create one from scr
 ### Option A: Use the AF Template (Recommended)
 
 ```bash
-# Clone the AF-optimized React template
-git clone https://github.com/alternatefutures/template-react my-react-app
+# Clone the Alternate Clouds React template
+git clone https://github.com/alternatefutures/template-cloud-react my-react-app
 cd my-react-app
 
 # Install dependencies
@@ -156,7 +152,7 @@ npx serve build
 
 :::
 
-## Step 4: Authenticate with AF
+## Step 4: Authenticate with Alternate Clouds
 
 If you have not already authenticated:
 
@@ -173,33 +169,23 @@ export AF_TOKEN=pat_your_token_here
 ::: code-group
 
 ```bash [Vite]
-# Initialize AF site configuration
-acc sites init
-
-# When prompted, configure:
-#   Site name: my-react-app
-#   Build command: npm run build
-#   Output directory: dist
-#   Storage network: ipfs
+# acc.config: { "slug": "my-react-app", "buildCommand": "npm run build", "distDir": "dist" }
 
 # Deploy to decentralized storage
-acc sites deploy
+acc services deploy
 ```
 
 ```bash [Create React App]
-# Initialize AF site configuration
-acc sites init
-
-# When prompted, configure:
-#   Site name: my-react-app
-#   Build command: npm run build
-#   Output directory: build
-#   Storage network: ipfs
+# acc.config: { "slug": "my-react-app", "buildCommand": "npm run build", "distDir": "build" }
 
 # Deploy to decentralized storage
-acc sites deploy
+acc services deploy
 ```
 
+:::
+
+::: info What this maps to in code
+`acc services deploy` is the CLI's only deploy subcommand — see [the CLI's actual command surface](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts). `slug`, `buildCommand`, and `distDir` are real [acc.config schema](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts) fields.
 :::
 
 You should see output like:
@@ -276,8 +262,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Deploy to AF
-        run: npx @alternatefutures/cli sites deploy ./dist --network ipfs
+      - name: Deploy to Alternate Clouds
+        run: npx @alternatefutures/cli services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN }}
 ```
@@ -296,12 +282,19 @@ const af = new AlternateFuturesSdk({
     personalAccessToken: process.env.AF_TOKEN,
     projectId: process.env.AF_PROJECT_ID,
   }),
+  // Required — the SDK throws EnvNotSetError if these are unset
+  ipfsStorageApiUrl: process.env.SDK__IPFS__STORAGE_API_URL,
+  uploadProxyApiUrl: process.env.SDK__UPLOAD_PROXY_API_URL,
 });
 
-// Deploy the build output
-const result = await af.ipfs().add('./dist');
-console.log('Deployed! CID:', result.pin.cid);
+// Upload the build directory. addFromPath() returns an array of results.
+const results = await af.ipfs().addFromPath('./dist');
+console.log('Deployed! CID:', results[0].cid);
 ```
+
+::: info What this maps to in code
+Signatures and the `UploadResult` shape (`{ cid, size, path }`) come from [the SDK IPFS client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipfs.ts): `add(file: IpfsFile)` for a single file, `addFromPath(path)` for a directory.
+:::
 
 ## Environment Variables
 

--- a/docs/guides/ens.md
+++ b/docs/guides/ens.md
@@ -6,6 +6,10 @@ description: Connect your Alternate Futures sites to ENS domains for decentraliz
 
 Connect your Alternate Futures sites to Ethereum Name Service (ENS) domains for decentralized, human-readable URLs.
 
+::: tip What this maps to in code
+ENS records are managed through the SDK's [`ens.ts` client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ens.ts) (`create`, `list`, `getByName`, `verify`, `delete`). The `acc` CLI does not register an `ens` command ([cli.ts](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts)), so ENS management is SDK-only.
+:::
+
 ## What is ENS?
 
 ENS (Ethereum Name Service) is a distributed, open naming system based on the Ethereum blockchain. It allows you to:
@@ -22,23 +26,14 @@ ENS (Ethereum Name Service) is a distributed, open naming system based on the Et
 
 ## Creating an ENS Record
 
-::: code-group
-
-```bash [CLI]
-# Create an ENS record for your site
-acc ens create
-
-# You'll be prompted for:
-# - ENS name (e.g., mysite.eth)
-# - Site to link
-# - IPNS record to use
-```
-
-```typescript [SDK]
-import { AlternateFuturesSdk } from '@alternatefutures/sdk/node';
+```typescript
+import { AlternateFuturesSdk, PersonalAccessTokenService } from '@alternatefutures/sdk/node';
 
 const af = new AlternateFuturesSdk({
-  personalAccessToken: process.env.AF_TOKEN
+  accessTokenService: new PersonalAccessTokenService({
+    personalAccessToken: process.env.AF_TOKEN,
+    projectId: process.env.AF_PROJECT_ID,
+  }),
 });
 
 // Create an ENS record
@@ -52,18 +47,9 @@ console.log('ENS Record created:', ensRecord.name);
 console.log('Content hash:', ensRecord.ipnsRecord.hash);
 ```
 
-:::
-
 ## Listing ENS Records
 
-::: code-group
-
-```bash [CLI]
-# List all ENS records
-acc ens list
-```
-
-```typescript [SDK]
+```typescript
 // List all ENS records
 const records = await af.ens().list();
 
@@ -73,20 +59,9 @@ records.forEach(record => {
 });
 ```
 
-:::
-
 ## Viewing ENS Record Details
 
-::: code-group
-
-```bash [CLI]
-# Get details for a specific ENS record
-acc ens detail
-
-# You'll be prompted to select the ENS record
-```
-
-```typescript [SDK]
+```typescript
 // Get ENS record by name
 const record = await af.ens().getByName({ name: 'mysite.eth' });
 
@@ -96,39 +71,29 @@ console.log('Content Hash:', record.ipnsRecord.hash);
 console.log('Status:', record.status);
 ```
 
-:::
-
 ## Verifying ENS Setup
 
 After creating an ENS record, you need to manually update your ENS domain's content hash:
 
-::: code-group
-
-```bash [CLI]
-# Verify your ENS setup
-acc ens verify
-
-# This checks if your ENS domain's content hash
-# matches the IPNS record from Alternate Futures
-```
-
-```typescript [SDK]
-// Get the content hash you need to set
+```typescript
+// Look up the content hash you need to set on-chain
 const record = await af.ens().getByName({ name: 'mysite.eth' });
 console.log('Set your ENS content hash to:', record.ipnsRecord.hash);
 
-// The SDK doesn't automatically update ENS
-// You must do this manually via ENS interface
-```
+// After you update the content hash in the ENS Manager,
+// confirm the link is recognized:
+await af.ens().verify({ id: record.id });
 
-:::
+// Note: the SDK does not update ENS on-chain for you.
+// Set the content hash manually via the ENS Manager.
+```
 
 ## Setting Up ENS Content Hash
 
-1. **Get your IPNS hash** from Alternate Futures:
-   ```bash
-   acc ens detail
-   # Note the IPNS hash (starts with /ipns/...)
+1. **Get your IPNS hash** from Alternate Futures via the SDK:
+   ```typescript
+   const record = await af.ens().getByName({ name: 'mysite.eth' });
+   console.log(record.ipnsRecord.hash); // starts with /ipns/...
    ```
 
 2. **Go to ENS Manager** at [app.ens.domains](https://app.ens.domains)
@@ -139,28 +104,17 @@ console.log('Set your ENS content hash to:', record.ipnsRecord.hash);
 
 5. **Confirm the transaction** on Ethereum
 
-6. **Verify** the setup:
-   ```bash
-   acc ens verify
+6. **Verify** the setup with the SDK:
+   ```typescript
+   await af.ens().verify({ id: record.id });
    ```
 
 ## Deleting an ENS Record
 
-::: code-group
-
-```bash [CLI]
-# Delete an ENS record
-acc ens delete
-
-# You'll be prompted to select which ENS record to delete
-```
-
-```typescript [SDK]
+```typescript
 // Delete an ENS record
 await af.ens().delete({ id: 'ens-record-id' });
 ```
-
-:::
 
 ## How ENS Integration Works
 
@@ -224,7 +178,7 @@ No manual ENS updates needed after initial setup!
 
 ### ENS Verification Fails
 
-**Problem:** `acc ens verify` shows mismatch
+**Problem:** `af.ens().verify(...)` reports a mismatch
 
 **Solutions:**
 - Wait 5-10 minutes for Ethereum blockchain confirmation
@@ -239,7 +193,7 @@ No manual ENS updates needed after initial setup!
 **Solutions:**
 - Confirm browser has ENS support (try Brave)
 - Use `.eth.link` gateway: `mysite.eth.link`
-- Check IPNS record is published: `acc ipns list`
+- Check the IPNS record is published: `af.ipns().listRecords()`
 - Verify content hash in ENS manager
 
 ### Content Not Updating
@@ -247,7 +201,7 @@ No manual ENS updates needed after initial setup!
 **Problem:** ENS shows old version of site
 
 **Solutions:**
-- Check IPNS record updated: `acc ipns list`
+- Check the IPNS record updated: `af.ipns().listRecords()`
 - IPNS propagation can take 5-10 minutes
 - Clear browser cache
 - Try different ENS gateway

--- a/docs/guides/functions.md
+++ b/docs/guides/functions.md
@@ -1,14 +1,14 @@
 ---
-description: Deploy serverless edge functions on decentralized infrastructure with optional SGX encryption using Alternate Futures Cloud Functions.
+description: Deploy serverless functions on decentralized infrastructure, with an optional SGX flag, using Alternate Futures Cloud Functions.
 ---
 
 # Cloud Functions
 
-Deploy serverless edge functions on decentralized infrastructure with Alternate Futures Functions.
+Deploy serverless functions on decentralized infrastructure with Alternate Futures Cloud Functions.
 
 ## What are Cloud Functions?
 
-Cloud Functions are serverless compute that runs on the edge, close to your users. They enable:
+Cloud Functions are serverless compute that runs on decentralized infrastructure. Use them to build:
 
 - **API Endpoints** - Create backend APIs without managing servers
 - **Dynamic Content** - Generate personalized content at the edge
@@ -18,24 +18,24 @@ Cloud Functions are serverless compute that runs on the edge, close to your user
 
 ## Function Runtime
 
-Functions run in a secure JavaScript/TypeScript runtime with:
+Functions run in a JavaScript/TypeScript runtime with:
 
 - Node.js-compatible APIs
-- Access to Web APIs (fetch, Request, Response)
-- Optional SGX (Software Guard Extensions) for enhanced security
-- Automatic scaling based on demand
+- Web APIs (`fetch`, `Request`, `Response`)
+- An optional SGX (Software Guard Extensions) deployment flag for workloads that need extra isolation
+
+::: info What this maps to in code
+- **SDK:** [functions client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/functions.ts) — `create`, `deploy`, `list`, `listDeployments`, `update`, `delete`.
+- **API:** [`AFFunction` data model](https://github.com/alternatefutures/service-cloud-api/blob/main/prisma/schema.prisma) and [`AFFunction` GraphQL type](https://github.com/alternatefutures/service-cloud-api/blob/main/src/schema/typeDefs.ts) — exposes `invokeUrl`, `routes`, `status`.
+:::
+
+::: tip CLI
+There is no `acc functions` command. Functions are created and deployed through the **SDK / GraphQL API** and served as services via `acc services`. The examples below use the SDK.
+:::
 
 ## Creating a Function
 
 ::: code-group
-
-```bash [CLI]
-# Create a new function
-acc functions create --name my-function
-
-# Create and attach to a site
-acc functions create --name my-function --site-id <site-id>
-```
 
 ```typescript [SDK]
 import { AlternateFuturesSdk, PersonalAccessTokenService } from '@alternatefutures/sdk/node';
@@ -121,36 +121,16 @@ export default async function handler(request) {
 
 ::: code-group
 
-```bash [CLI]
-# Deploy function code
-acc functions deploy \
-  --function-id <function-id> \
-  --code ./dist
-
-# Deploy with SGX security
-acc functions deploy \
-  --function-id <function-id> \
-  --code ./dist \
-  --sgx
-
-# Deploy with assets
-acc functions deploy \
-  --function-id <function-id> \
-  --code ./dist \
-  --assets ./public
-```
-
 ```typescript [SDK]
-// First, upload your code to IPFS
-const codeUpload = await af.uploadProxy().uploadDirectory({
-  path: './dist'
-});
+// First, upload your built function bundle to storage to get a CID.
+// (Use the storage client's upload method; it returns a CID.)
+const { cid } = await af.storage().uploadContent(/* your bundle */);
 
-// Deploy the function
+// Deploy the function using that CID
 const deployment = await af.functions().deploy({
   functionId: 'function-id',
-  cid: codeUpload.pin.cid,
-  sgx: true, // optional: enable SGX
+  cid,
+  sgx: true, // optional: request an SGX-enabled deployment
   blake3Hash: 'hash', // optional: for verification
   assetsCid: 'assets-cid' // optional: static assets
 });
@@ -164,11 +144,6 @@ console.log('Deployment ID:', deployment.id);
 
 ::: code-group
 
-```bash [CLI]
-# List all functions
-acc functions list
-```
-
 ```typescript [SDK]
 // List all functions
 const functions = await af.functions().list();
@@ -176,7 +151,7 @@ const functions = await af.functions().list();
 functions.forEach(func => {
   console.log(`${func.name} (${func.slug})`);
   console.log(`Status: ${func.status}`);
-  console.log(`URL: https://${func.slug}.af-functions.app`);
+  console.log(`URL: ${func.invokeUrl}`); // e.g. https://crooked-bland-jackal.dev.on-af-functions.app
 });
 ```
 
@@ -185,11 +160,6 @@ functions.forEach(func => {
 ## Viewing Function Deployments
 
 ::: code-group
-
-```bash [CLI]
-# List deployments for a function
-acc functions list-deployments --function-id <function-id>
-```
 
 ```typescript [SDK]
 // List function deployments
@@ -210,14 +180,6 @@ deployments.forEach(dep => {
 
 ::: code-group
 
-```bash [CLI]
-# Update function configuration
-acc functions update \
-  --function-id <function-id> \
-  --name new-name \
-  --routes '/api/v2/*=handler.js'
-```
-
 ```typescript [SDK]
 // Update function
 await af.functions().update({
@@ -235,11 +197,6 @@ await af.functions().update({
 ## Deleting a Function
 
 ::: code-group
-
-```bash [CLI]
-# Delete a function
-acc functions delete --function-id <function-id>
-```
 
 ```typescript [SDK]
 // Delete a function
@@ -287,25 +244,23 @@ Set variables during deployment or in your build process.
 
 ## SGX (Software Guard Extensions)
 
-Enable SGX for enhanced security and privacy:
+Request an SGX-enabled deployment with the `sgx` flag:
 
-```bash
-acc functions deploy \
-  --function-id <function-id> \
-  --code ./dist \
-  --sgx
+```typescript
+await af.functions().deploy({
+  functionId: 'function-id',
+  cid,
+  sgx: true,
+});
 ```
 
-SGX provides:
-- **Encrypted Execution** - Code runs in encrypted memory
-- **Attestation** - Verify code hasn't been tampered with
-- **Confidential Computing** - Protect sensitive data during processing
+SGX is an optional deployment flag that requests your function run in an SGX-enabled environment for additional isolation of sensitive workloads. Exact guarantees and availability depend on the target provider.
 
 ## Function URLs
 
 Access your functions via:
 
-- **Default URL**: `https://<function-slug>.af-functions.app`
+- **Default URL**: returned by the API as `func.invokeUrl` (pattern `https://<function-slug>.<env>.on-af-functions.app`)
 - **Custom Domain**: Configure custom domains for your functions
 - **Site Integration**: Mount functions on specific routes within your site
 
@@ -433,7 +388,7 @@ export default async function handler(request) {
 
 **What is CORS?**
 
-CORS (Cross-Origin Resource Sharing) is a security feature that browsers use to prevent websites from making requests to different domains without permission. When your web app (e.g., `myapp.com`) tries to call your function (e.g., `function.af-functions.app`), the browser blocks it unless your function explicitly allows it.
+CORS (Cross-Origin Resource Sharing) is a security feature that browsers use to prevent websites from making requests to different domains without permission. When your web app (e.g., `myapp.com`) tries to call your function (e.g., `function.on-af-functions.app`), the browser blocks it unless your function explicitly allows it.
 
 **Solution 1: Basic CORS Headers**
 

--- a/docs/guides/gateways.md
+++ b/docs/guides/gateways.md
@@ -4,17 +4,13 @@ description: Create dedicated IPFS gateways with custom domains for fast, reliab
 
 # Private Gateways
 
-Create dedicated IPFS gateways with custom domains for fast, reliable access to your decentralized content.
+A private gateway is a dedicated IPFS endpoint you own and map to a custom domain, giving your users fast, branded access to content you store on Alternate Clouds. Gateways are managed through the SDK today.
 
 ## What are Private Gateways?
 
-Private Gateways are dedicated IPFS gateway infrastructure that provides:
+Private Gateways are dedicated IPFS gateway endpoints you own and manage. Each gateway has a `name`, a `slug`, and an associated DNS `zone`, and can be mapped to a custom domain for branded access to your IPFS content.
 
-- **Custom Domains** - Access content via your own domain
-- **Enhanced Performance** - Dedicated resources for faster loading
-- **CDN Integration** - Global edge caching
-- **Access Control** - Restrict who can access your content
-- **Custom Configuration** - Configure caching, headers, and more
+> **What this maps to in code:** the gateway fields exposed by the API are defined on the [PrivateGateway GraphQL type](https://github.com/alternatefutures/service-cloud-api/blob/main/src/schema/typeDefs.ts) (`name`, `slug`, `zone`).
 
 ## Why Use Private Gateways?
 
@@ -35,48 +31,35 @@ Private Gateways are dedicated IPFS gateway infrastructure that provides:
 
 ## Creating a Private Gateway
 
-::: code-group
+Gateways are managed through the SDK (`af.privateGateways()`); there is no `acc gateways` CLI command.
 
-```bash [CLI]
-# Create a new private gateway
-acc gateways create
-
-# You'll be prompted for:
-# - Gateway name
-# - Zone/Domain to use
-```
-
-```typescript [SDK]
-import { AlternateFuturesSdk } from '@alternatefutures/sdk/node';
+```typescript
+import { AlternateFuturesSdk, PersonalAccessTokenService } from '@alternatefutures/sdk/node';
 
 const af = new AlternateFuturesSdk({
-  personalAccessToken: process.env.AF_TOKEN
+  accessTokenService: new PersonalAccessTokenService({
+    personalAccessToken: process.env.AF_TOKEN,
+    projectId: '<your-project-id>',
+  }),
 });
 
 // Create a private gateway
-const gateway = await af.privateGateway().create({
+const gateway = await af.privateGateways().create({
   name: 'My Gateway',
-  zoneId: 'zone-id' // DNS zone for your domain
+  zoneId: 'zone-id', // DNS zone for your domain
 });
 
 console.log('Gateway created:', gateway.name);
 console.log('Gateway slug:', gateway.slug);
 ```
 
-:::
+> **What this maps to in code:** the [AlternateFuturesSdk constructor](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/AlternateFuturesSdk.ts) requires `accessTokenService` and exposes the `privateGateways()` accessor; the [PrivateGatewayClient](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/privateGateway.ts) implements `create({ name, zoneId })`, `list()`, `get({ id })`, `getBySlug({ slug })`, `update({ id, name })`, and `delete({ id })`.
 
 ## Listing Gateways
 
-::: code-group
-
-```bash [CLI]
-# List all private gateways
-acc gateways list
-```
-
-```typescript [SDK]
+```typescript
 // List all gateways
-const gateways = await af.privateGateway().list();
+const gateways = await af.privateGateways().list();
 
 gateways.forEach(gw => {
   console.log(`${gw.name} (${gw.slug})`);
@@ -84,75 +67,38 @@ gateways.forEach(gw => {
 });
 ```
 
-:::
-
 ## Viewing Gateway Details
 
-::: code-group
-
-```bash [CLI]
-# Get details for a specific gateway
-acc gateways detail
-
-# You'll be prompted to select the gateway
-```
-
-```typescript [SDK]
+```typescript
 // Get gateway by ID
-const gateway = await af.privateGateway().get({ id: 'gateway-id' });
+const gateway = await af.privateGateways().get({ id: 'gateway-id' });
 
 console.log('Name:', gateway.name);
 console.log('Slug:', gateway.slug);
 console.log('Created:', gateway.createdAt);
 
 // Get gateway by slug
-const gatewayBySlug = await af.privateGateway().getBySlug({
+const gatewayBySlug = await af.privateGateways().getBySlug({
   slug: 'my-gateway'
 });
 ```
 
-:::
-
 ## Updating a Gateway
 
-::: code-group
-
-```bash [CLI]
-# Update gateway configuration
-acc gateways update
-
-# You'll be prompted to:
-# 1. Select the gateway
-# 2. Enter new name
-```
-
-```typescript [SDK]
+```typescript
 // Update gateway
-await af.privateGateway().update({
+await af.privateGateways().update({
   id: 'gateway-id',
   name: 'Updated Gateway Name'
 });
 ```
 
-:::
-
 ## Deleting a Gateway
 
-::: code-group
-
-```bash [CLI]
-# Delete a gateway
-acc gateways delete
-
-# You'll be prompted to select which gateway to delete
-```
-
-```typescript [SDK]
+```typescript
 // Delete a gateway
-await af.privateGateway().delete({ id: 'gateway-id' });
+await af.privateGateways().delete({ id: 'gateway-id' });
 ```
-
-:::
 
 ## Setting Up Custom Domain
 
@@ -165,23 +111,19 @@ Add a CNAME record pointing to your gateway:
 ```
 Type: CNAME
 Name: gateway (or @)
-Value: <gateway-slug>.af-gateway.app
+Value: <gateway-slug>.<gateway-domain>
 TTL: 3600
 ```
 
-### 2. Create Domain in Alternate Futures
+> The canonical gateway domain is not yet finalized in the published tooling, and this guide and storage.md currently disagree (`af-gateway.app` vs `af-gateways.app`). Confirm the correct host before configuring DNS.
 
-```bash
-acc domains create \
-  --hostname gateway.yourdomain.com \
-  --gateway-id <gateway-id>
-```
+### 2. Create the Domain in Alternate Clouds
 
-### 3. Verify Domain
+Domain management is available through the SDK (`af.domains()`); there is no `acc domains` CLI command. Create the domain against your gateway with the domains client.
 
-```bash
-acc domains verify --domain-id <domain-id>
-```
+### 3. Verify the Domain
+
+Verify the domain through the same `af.domains()` client. See the domains client for the exact method signatures.
 
 ## Accessing Content Through Gateway
 
@@ -202,11 +144,13 @@ https://gateway.yourdomain.com/ipns/<IPNS-NAME>
 https://gateway.yourdomain.com/ipfs/<CID>/path/to/file.html
 ```
 
-## Gateway Configuration
+## Roadmap
 
-### Caching Strategy
+::: warning Planned, not yet configurable
+The API today exposes only a gateway's `name`, `slug`, and `zone` (create/list/get/update/delete). The capabilities below — edge caching and invalidation, custom TTL and headers, access control (IP allowlist, token auth, geo-blocking, rate limiting), compression, image optimization, DDoS protection, analytics, and uptime SLAs — are on the roadmap and are not configurable through the CLI, SDK, or API yet. Do not rely on them in production.
+:::
 
-Private gateways automatically cache content with:
+### Caching Strategy (planned)
 
 - **Edge Caching** - Content cached at CDN edge nodes globally
 - **Smart Invalidation** - Automatic cache updates for new versions
@@ -284,14 +228,6 @@ Optimize images served through your gateway:
 - WebP conversion for supported browsers
 - Automatic resizing based on request
 - Lazy loading support
-
-### 3. Preloading
-
-Preload frequently accessed content:
-```bash
-# Pin content to your gateway
-acc storage pin <CID> --gateway-id <gateway-id>
-```
 
 ### 4. CDN Distribution
 

--- a/docs/guides/glossary.md
+++ b/docs/guides/glossary.md
@@ -188,7 +188,7 @@ A node-based interface for creating AI image and video generation workflows, esp
 
 A secret token that authenticates your application to access Alternate Futures services. Like a password but for code.
 
-**Format:** Starts with `af_` like `af_1234567890abcdef`
+**Format:** Personal Access Tokens are formatted `af_<environment>_<random>`, e.g. `af_prod_a1b2c3...` (see [`token.service.ts`](https://github.com/alternatefutures/service-auth/blob/main/src/services/token.service.ts))
 
 **Security:** Never commit to version control, always use environment variables.
 
@@ -278,7 +278,7 @@ Encryption certificates that enable HTTPS for secure web connections. The lock i
 
 A text-based interface for interacting with software. The Alternate Futures CLI lets you deploy from your terminal.
 
-**Example:** `acc sites deploy ./dist --network ipfs`
+**Example:** `acc services deploy`
 
 ### SDK (Software Development Kit)
 
@@ -290,7 +290,7 @@ A set of tools and libraries for developers to build applications. The Alternate
 
 Configuration values stored outside your code, typically for secrets or environment-specific settings.
 
-**Example:** `AF_TOKEN=af_pat_123...`
+**Example:** `AF_TOKEN=af_prod_123...`
 
 **Storage:** `.env` files locally, platform settings in production.
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -4,11 +4,11 @@ description: Learn how to deploy sites, AI agents, and cloud functions to decent
 
 # Platform Guides
 
-Welcome to the Alternate Futures platform guides. These guides will help you get started and master the platform.
+Guides for deploying and operating sites, AI agents, and cloud functions on Alternate Futures.
 
 ## What is Alternate Futures?
 
-Alternate Futures is a platform that lets you deploy websites and AI agents to **decentralized infrastructure**—meaning your applications run on distributed networks instead of centralized cloud providers like AWS or Google Cloud.
+Alternate Futures is a platform that lets you deploy websites and AI agents to **decentralized infrastructure**—your applications run across many independent operators instead of a single centralized cloud provider like AWS or Google Cloud.
 
 ### Why Decentralized?
 
@@ -38,7 +38,7 @@ Alternate Futures is a platform that lets you deploy websites and AI agents to *
 **Privacy-Focused Use Cases:**
 - **Whistleblower Platforms** - Anonymous document sharing without server logs or centralized tracking
 - **Activist Websites** - Content that can't be censored or seized by authorities
-- **Privacy-First Apps** - Run functions with SGX encryption where not even the host can see your data
+- **Privacy-First Apps** - Run functions in a confidential compute environment (a hardware-backed TEE, via Phala) where not even the host can see your data
 - **Journalist Archives** - Permanent, tamper-proof storage for sensitive documents
 - **Alternative Social Networks** - Build platforms without corporate surveillance or data mining
 

--- a/docs/guides/ipns.md
+++ b/docs/guides/ipns.md
@@ -6,6 +6,10 @@ description: Create mutable pointers to IPFS content with IPNS on Alternate Futu
 
 Use IPNS to create mutable pointers to your IPFS content, enabling dynamic updates without changing URLs.
 
+::: tip What this maps to in code
+IPNS is managed entirely through the SDK's [`ipns.ts` client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipns.ts) (`createRecordForSite`, `listRecords`, `publishRecord`, `resolveName`, `deleteRecord`). The `acc` CLI does not register an `ipns` command ([cli.ts](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts)), so all examples below use the SDK.
+:::
+
 ## What is IPNS?
 
 IPNS (InterPlanetary Name System) is a system for creating mutable pointers to IPFS content. While IPFS content is immutable (CID changes with each update), IPNS provides:
@@ -32,44 +36,28 @@ graph LR
 
 ## Creating an IPNS Record
 
-::: code-group
-
-```bash [CLI]
-# Create IPNS record for a site
-acc ipns create --site-id <site-id>
-
-# The IPNS record will automatically point to
-# the site's latest deployment
-```
-
-```typescript [SDK]
-import { AlternateFuturesSdk } from '@alternatefutures/sdk/node';
+```typescript
+import { AlternateFuturesSdk, PersonalAccessTokenService } from '@alternatefutures/sdk/node';
 
 const af = new AlternateFuturesSdk({
-  personalAccessToken: process.env.AF_TOKEN
+  accessTokenService: new PersonalAccessTokenService({
+    personalAccessToken: process.env.AF_TOKEN,
+    projectId: process.env.AF_PROJECT_ID,
+  }),
 });
 
-// Create IPNS record for a site
+// Create an IPNS record for a site
 const ipnsRecord = await af.ipns().createRecordForSite({
-  siteId: 'site-id'
+  siteId: 'site-id',
 });
 
 console.log('IPNS Name:', ipnsRecord.name);
 console.log('Current Hash:', ipnsRecord.hash);
 ```
 
-:::
-
 ## Listing IPNS Records
 
-::: code-group
-
-```bash [CLI]
-# List all IPNS records
-acc ipns list
-```
-
-```typescript [SDK]
+```typescript
 // List all IPNS records
 const records = await af.ipns().listRecords();
 
@@ -80,24 +68,11 @@ records.forEach(record => {
 });
 ```
 
-:::
-
 ## Publishing Updates
 
-When you deploy a new version of your site, the IPNS record automatically updates to point to the new content.
+To point an IPNS name at newly deployed content, publish the new hash to the record:
 
-You can also manually publish a new hash:
-
-::: code-group
-
-```bash [CLI]
-# Publish new content to IPNS record
-acc ipns publish \
-  --ipns-id <ipns-id> \
-  --hash <new-ipfs-cid>
-```
-
-```typescript [SDK]
+```typescript
 // Publish new content to IPNS
 await af.ipns().publishRecord({
   id: 'ipns-record-id',
@@ -105,20 +80,11 @@ await af.ipns().publishRecord({
 });
 ```
 
-:::
-
 ## Resolving IPNS Names
 
 Check what content an IPNS name currently points to:
 
-::: code-group
-
-```bash [CLI]
-# Resolve IPNS name to current CID
-acc ipns resolve --name <ipns-name>
-```
-
-```typescript [SDK]
+```typescript
 // Resolve IPNS name
 const resolved = await af.ipns().resolveName({
   name: '/ipns/k51qzi5uqu5di...'
@@ -127,25 +93,14 @@ const resolved = await af.ipns().resolveName({
 console.log('Current CID:', resolved);
 ```
 
-:::
-
 ## Deleting an IPNS Record
 
-::: code-group
-
-```bash [CLI]
-# Delete an IPNS record
-acc ipns delete --ipns-id <ipns-id>
-```
-
-```typescript [SDK]
+```typescript
 // Delete IPNS record
 await af.ipns().deleteRecord({
   id: 'ipns-record-id'
 });
 ```
-
-:::
 
 ## Accessing Content via IPNS
 
@@ -177,24 +132,24 @@ https://yoursite.eth.link
 https://yoursite.eth.limo
 ```
 
-## Automatic Updates
+## Publishing a New Version
 
-IPNS records automatically update when you deploy:
+Each deployment produces a new IPFS CID. To point an existing IPNS name at that CID, publish it explicitly with the SDK:
 
-```bash
-# Deploy new version of site
-acc sites deploy ./dist --site-id <site-id>
-
-# IPNS record automatically updates to new CID
-# Users accessing /ipns/<name> see new version
+```typescript
+// After deploying and obtaining the new CID
+await af.ipns().publishRecord({
+  id: 'ipns-record-id',
+  hash: 'QmNewContentHash...',
+});
 ```
 
 The flow:
-1. Deploy creates new IPFS CID
-2. Deployment completes successfully
-3. Site's IPNS record updated to new CID
-4. Propagation across IPFS network (1-2 minutes)
-5. Users see updated content
+1. Deploy your site, producing a new IPFS CID
+2. Publish the new CID to your existing IPNS record (SDK call above)
+3. The IPNS name resolves to the new CID
+4. Changes propagate across the IPFS network (typically 1-2 minutes)
+5. Users accessing `/ipns/<name>` see the updated content
 
 ## Use Cases
 
@@ -293,7 +248,7 @@ Improve IPNS performance:
 **Solutions:**
 - Wait 2-3 minutes for propagation
 - Try different gateway
-- Verify IPNS record exists: `acc ipns list`
+- Verify the IPNS record exists with the SDK: `af.ipns().listRecords()`
 - Check network connectivity to IPFS
 
 ### Old Content Still Showing
@@ -303,7 +258,7 @@ Improve IPNS performance:
 **Solutions:**
 - Clear browser cache
 - Wait for propagation (2-5 minutes)
-- Verify publish succeeded: `acc ipns resolve`
+- Verify the publish succeeded with the SDK: `af.ipns().resolveName({ name })`
 - Try different IPFS gateway
 
 ### Slow Resolution
@@ -321,14 +276,16 @@ Improve IPNS performance:
 For advanced users who want to manage their own IPNS keys:
 
 ```bash
-# Generate IPNS key locally
+# Generate an IPNS key locally with the IPFS CLI
 ipfs key gen my-site
 
-# Publish with custom key
+# Publish with your custom key
 ipfs name publish --key=my-site <CID>
-
-# Import key to Alternate Futures (contact support)
 ```
+
+::: warning
+Alternate Futures manages IPNS keys on your behalf; importing an externally generated key is not currently supported through the SDK. Use the SDK's `createRecordForSite` to have a key provisioned for you.
+:::
 
 ## Best Practices
 

--- a/docs/guides/migrate-from-fleek.md
+++ b/docs/guides/migrate-from-fleek.md
@@ -4,7 +4,7 @@ description: Step-by-step guide to migrate your sites, IPFS content, domains, an
 
 # Migrate from Fleek
 
-Fleek has pivoted away from Web3 hosting to focus on AI inference. If you have sites, storage, or deployments on Fleek, this guide walks you through migrating everything to Alternate Futures.
+Fleek has pivoted away from Web3 hosting to focus on AI inference. If you still run sites, storage, or deployments there, this guide moves all of it onto Alternate Clouds — decentralized hosting from Alternate Futures across IPFS, Filecoin, and Arweave.
 
 **Time to complete:** 15-30 minutes per site
 
@@ -21,7 +21,7 @@ Fleek has pivoted away from Web3 hosting to focus on AI inference. If you have s
 | **IPFS support** | Yes | Yes |
 | **Arweave support** | Limited | Full |
 | **Filecoin support** | No | Yes |
-| **AI agents** | No | Yes (Eliza, ComfyUI, custom) |
+| **AI agents** | No | Yes (via `acc services create` templates) |
 | **Observability** | No | Yes (OpenTelemetry) |
 
 ## Before You Start
@@ -34,11 +34,15 @@ Fleek has pivoted away from Web3 hosting to focus on AI inference. If you have s
 
 2. **Create an Alternate Futures account** at [app.alternatefutures.ai](https://app.alternatefutures.ai)
 
-3. **Install the Alternate Futures CLI:**
+3. **Install the Alternate Clouds CLI:**
    ```bash
    npm install -g @alternatefutures/cli
    acc login
    ```
+
+   ::: warning CLI binary name
+   Commands in this guide use `acc`. If your installed version still exposes the legacy `af` binary, update to the latest `@alternatefutures/cli` or substitute `af` for `acc`.
+   :::
 
 ## Step 1: Migrate Your Site
 
@@ -52,13 +56,21 @@ fleek sites init
 fleek sites deploy
 ```
 
-**New (Alternate Futures):**
+**New (Alternate Clouds):**
 ```bash
-acc sites init
-acc sites deploy
+# Create a service (choose a starter template when prompted)
+acc services create
+
+# Deploy it — pass the service id, or omit to pick interactively
+acc services deploy [id]
+
+# List deployments and their URLs
+acc deployments
 ```
 
-The `acc sites init` command creates an `af.config.json` file. If you had a `fleek.json`, here is how the configuration maps:
+Deploys run through `acc services`; the full set of registered top-level commands (`login`, `logout`, `projects`, `services`, `deployments`, `billing`, `ssh`) is defined in [the acc CLI command set](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts).
+
+If you keep an `af.config.json` in your project, here is how a `fleek.json` maps onto it:
 
 **Fleek config (`fleek.json`):**
 ```json
@@ -70,7 +82,7 @@ The `acc sites init` command creates an `af.config.json` file. If you had a `fle
 }
 ```
 
-**Alternate Futures config (`af.config.json`):**
+**Alternate Clouds config (`af.config.json`):**
 ```json
 {
   "sites": [
@@ -82,6 +94,8 @@ The `acc sites init` command creates an `af.config.json` file. If you had a `fle
   ]
 }
 ```
+
+> **What this maps to in code:** these fields are the [`af.config` schema (sites: slug/distDir/buildCommand)](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts).
 
 ### From Fleek SDK to AF SDK
 
@@ -110,21 +124,23 @@ const af = new AlternateFuturesSdk({
   }),
 });
 
-const result = await af.ipfs().add('./dist');
+// Upload a directory from disk
+const [result] = await af.ipfs().addFromPath('./dist');
+console.log('CID:', result.cid.toString());
 ```
 
-The SDK API is largely compatible. The main changes are the import path and environment variable names.
+The import path and environment variable names change. Note one API difference: `af.ipfs().add()` takes an in-memory `{ path, content }` file, while `af.ipfs().addFromPath('./dist')` uploads a directory and returns a `UploadResult[]` — see the [IPFS client (add / addFromPath)](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipfs.ts).
 
 ## Step 2: Migrate IPFS Content
 
 If you have content pinned on Fleek's IPFS infrastructure, you should re-pin it on Alternate Futures before Fleek's pinning service goes offline.
 
-```bash
-# If you have the original files, re-upload them
-acc storage add ./my-files
+There is no direct `acc` storage command today — re-pin through the SDK:
 
-# Or upload from a directory
-acc ipfs add ./my-content
+```typescript
+// Re-upload your files; the same bytes always produce the same CID
+const results = await af.ipfs().addFromPath('./my-content');
+console.log('CID:', results[0].cid.toString());
 ```
 
 Your CIDs will remain the same since IPFS content-addressing is deterministic -- the same files always produce the same CID.
@@ -144,13 +160,9 @@ dig yourdomain.com TXT
 
 ### Configure Domains on Alternate Futures
 
-```bash
-# Add your domain to your AF site
-acc domains create --siteSlug my-site --hostname yourdomain.com
-
-# Verify DNS configuration
-acc domains verify --hostname yourdomain.com
-```
+::: info Where to configure domains
+Custom domains are configured from the [Alternate Clouds dashboard](https://app.alternatefutures.ai) (a CLI `domains` command is not yet available). Add your hostname there, then update DNS at your registrar using the records the dashboard shows.
+:::
 
 ### Update DNS Records
 
@@ -168,7 +180,7 @@ TTL: 3600
 ```
 Type: A
 Name: @
-Value: [Platform IP from acc domains detail]
+Value: [Platform IP shown in the dashboard]
 TTL: 3600
 ```
 
@@ -189,7 +201,7 @@ See the [Custom Domains guide](./custom-domains.md) for full details.
 **New (Alternate Futures):**
 ```yaml
 - name: Deploy to Alternate Futures
-  run: npx @alternatefutures/cli sites deploy
+  run: npx @alternatefutures/cli services deploy
   env:
     AF_TOKEN: ${{ secrets.AF_TOKEN }}
     AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID }}
@@ -206,13 +218,7 @@ See the [Custom Domains guide](./custom-domains.md) for full details.
 
 If you had ENS domains linked through Fleek:
 
-```bash
-# Link your ENS domain to your AF site
-acc ens create --domain mysite.eth --siteSlug my-site
-
-# Verify the configuration
-acc ens verify --domain mysite.eth
-```
+ENS linking is available through the [Alternate Clouds dashboard](https://app.alternatefutures.ai) and the SDK ENS client (there is no `acc ens` command yet). Point your `.eth` name at the site's IPFS CID or IPNS record from there.
 
 ## Step 6: Clean Up
 
@@ -225,10 +231,10 @@ acc ens verify --domain mysite.eth
 
 Beyond replacing Fleek's functionality, Alternate Futures provides additional features:
 
-- **Filecoin storage** -- Cheaper long-term archival (~$0.03/GB/month)
-- **AI agent deployment** -- Deploy Eliza chatbots, ComfyUI image generators
+- **Filecoin storage** -- Cost-effective long-term archival (see current pricing in the dashboard)
+- **AI agent deployment** -- Deploy agents such as Eliza and ComfyUI via `acc services create` templates
 - **Observability** -- OpenTelemetry-based APM with distributed tracing
-- **Cloud functions** -- Serverless edge functions with optional SGX encryption
+- **Cloud functions** -- Serverless functions (confidential-compute options where available)
 - **Decentralized container registry** -- Self-hosted Docker registry on Akash
 - **Multi-method auth** -- Email, social OAuth, Web3 wallets (SIWE)
 

--- a/docs/guides/migrate-from-netlify.md
+++ b/docs/guides/migrate-from-netlify.md
@@ -4,7 +4,7 @@ description: Move your static sites, serverless functions, and custom domains fr
 
 # Migrate from Netlify
 
-Move your static sites from Netlify to Alternate Futures for decentralized hosting with IPFS, Filecoin, and Arweave storage options.
+Move your static sites from Netlify onto Alternate Clouds — decentralized hosting from Alternate Futures with IPFS, Filecoin, and Arweave storage.
 
 **Time to complete:** 15-30 minutes per site
 
@@ -34,12 +34,16 @@ Migrating from Netlify works best for **static sites** and **JAMstack apps** (Ne
 ## Step 1: Install and Authenticate
 
 ```bash
-# Install the Alternate Futures CLI
+# Install the Alternate Clouds CLI
 npm install -g @alternatefutures/cli
 
 # Authenticate
 acc login
 ```
+
+::: warning CLI binary name
+Commands here use `acc`. If your installed version still exposes the legacy `af` binary, update to the latest `@alternatefutures/cli` or substitute `af` for `acc`.
+:::
 
 ## Step 2: Update Your Configuration
 
@@ -59,7 +63,7 @@ Netlify uses `netlify.toml` for configuration. You will replace this with `af.co
   status = 200
 ```
 
-**New (`af.config.json` -- created by `acc sites init`):**
+**New (`af.config.json`):**
 ```json
 {
   "sites": [
@@ -72,6 +76,8 @@ Netlify uses `netlify.toml` for configuration. You will replace this with `af.co
 }
 ```
 
+> **What this maps to in code:** these fields are the [`af.config` schema](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts).
+
 ::: info SPA Redirects
 Netlify's `_redirects` file and redirect rules in `netlify.toml` are specific to Netlify. For single-page apps on IPFS, ensure your build produces a `200.html` or `index.html` fallback. Most SPA frameworks handle this automatically.
 :::
@@ -82,9 +88,15 @@ Build and deploy your site:
 
 ```bash
 npm run build
-acc sites init          # Select your output directory
-acc sites deploy
+
+# Create a service (choose a starter template when prompted)
+acc services create
+
+# Deploy it — pass the service id, or omit to pick interactively
+acc services deploy [id]
 ```
+
+These are the real registered commands — see [the acc CLI command set](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts).
 
 ### Framework Output Directories
 
@@ -125,13 +137,9 @@ export const main = (params) => {
 };
 ```
 
-Deploy the function:
-```bash
-acc functions create --name hello --path ./functions/hello.js
-acc functions deploy --name hello
-```
+Deploy functions from the [Alternate Clouds dashboard](https://app.alternatefutures.ai) or the SDK functions client — there is no `acc functions` command yet.
 
-See the [Cloud Functions guide](./functions.md) for full details on function deployment, environment variables, and SGX encryption.
+See the [Cloud Functions guide](./functions.md) for full details on function deployment and environment variables.
 
 ## Step 4: Migrate Custom Domains
 
@@ -143,13 +151,9 @@ See the [Cloud Functions guide](./functions.md) for full details on function dep
 
 ### Add Domain to Alternate Futures
 
-```bash
-# Add the domain to your site
-acc domains create --siteSlug my-site --hostname example.com
-
-# Get the required DNS records
-acc domains detail --hostname example.com
-```
+::: info Where to configure domains
+Add custom domains from the [Alternate Clouds dashboard](https://app.alternatefutures.ai) (a CLI `domains` command is not yet available). The dashboard shows the exact DNS records to set at your registrar.
+:::
 
 ### Update DNS Records
 
@@ -166,13 +170,10 @@ Value: cname.alternatefutures.ai
 ```
 Type: A
 Name: @
-Value: [IP from acc domains detail]
+Value: [IP shown in the dashboard]
 ```
 
-```bash
-# Verify DNS configuration
-acc domains verify --hostname example.com
-```
+The dashboard reports verification status once your DNS records propagate.
 
 ::: warning Netlify DNS Users
 If you used Netlify DNS as your nameserver, you will need to either migrate your nameservers to another provider (Cloudflare, Google DNS, etc.) or update records at Netlify DNS to point to Alternate Futures. We recommend migrating to a dedicated DNS provider for more control.
@@ -211,7 +212,7 @@ jobs:
         run: npm run build
 
       - name: Deploy
-        run: npx @alternatefutures/cli sites deploy
+        run: npx @alternatefutures/cli services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN }}
           AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID }}
@@ -220,7 +221,7 @@ jobs:
 ### Add Secrets
 
 1. Go to your GitHub repository **Settings** > **Secrets and variables** > **Actions**
-2. Add `AF_TOKEN` -- your personal access token (create one with `acc pat create --name "CI/CD"`)
+2. Add `AF_TOKEN` -- your personal access token (create one with [`acc pat create`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/pat/index.ts) `--name "CI/CD"`)
 3. Add `AF_PROJECT_ID` -- your project ID (find it with `acc projects list`)
 
 ## Step 6: Migrate Environment Variables
@@ -251,14 +252,14 @@ If your Netlify project uses environment variables:
 
 | Netlify Feature | Alternate Futures Equivalent |
 |-----------------|------------------------------|
-| Deploy previews | Every deployment gets a unique CID URL |
-| Netlify Functions | [Cloud Functions](./functions.md) with SGX encryption |
-| Edge Functions | Cloud Functions (edge deployment) |
+| Deploy previews | Each deployment is content-addressed on IPFS |
+| Netlify Functions | [Cloud Functions](./functions.md) (confidential-compute options where available) |
+| Edge Functions | [Cloud Functions](./functions.md) |
 | Netlify Analytics | [Observability & APM](./observability.md) |
 | Forms | Cloud Functions with form handling |
 | Identity | [Authentication](./authentication.md) with multi-method support |
 | Large Media | [Storage Management](./storage.md) on IPFS/Filecoin |
-| Split testing | Multiple deployments with unique CID URLs |
+| Split testing | Multiple content-addressed deployments |
 | `_redirects` / `_headers` | Build-time configuration (framework-level) |
 
 ## Troubleshooting

--- a/docs/guides/migrate-from-spheron.md
+++ b/docs/guides/migrate-from-spheron.md
@@ -4,7 +4,7 @@ description: Step-by-step guide to migrate your sites, storage, and deployments 
 
 # Migrate from Spheron
 
-Spheron has pivoted away from Web3 hosting to focus on GPU compute and AI inference. If you have sites, storage, or deployments on Spheron, this guide walks you through migrating everything to Alternate Futures.
+Spheron has pivoted away from Web3 hosting to focus on GPU compute and AI inference. If you still run sites, storage, or deployments there, this guide moves all of it onto Alternate Clouds — decentralized hosting from Alternate Futures across IPFS, Filecoin, and Arweave.
 
 **Time to complete:** 15-30 minutes per site
 
@@ -39,11 +39,15 @@ If you used Spheron primarily for GPU compute, that functionality is separate fr
 
 2. **Create an Alternate Futures account** at [app.alternatefutures.ai](https://app.alternatefutures.ai)
 
-3. **Install the Alternate Futures CLI:**
+3. **Install the Alternate Clouds CLI:**
    ```bash
    npm install -g @alternatefutures/cli
    acc login
    ```
+
+   ::: warning CLI binary name
+   Commands in this guide use `acc`. If your installed version still exposes the legacy `af` binary, update to the latest `@alternatefutures/cli` or substitute `af` for `acc`.
+   :::
 
 ## Step 1: Migrate Your Site
 
@@ -59,14 +63,16 @@ cd my-project
 # Build your project (if not already built)
 npm run build
 
-# Initialize AF configuration
-acc sites init
+# Create a service (choose a starter template when prompted)
+acc services create
 
-# Deploy to IPFS (default), Filecoin, or Arweave
-acc sites deploy
+# Deploy it — pass the service id, or omit to pick interactively
+acc services deploy [id]
 ```
 
-The `acc sites init` command creates an `af.config.json` file. Here is how Spheron's configuration maps:
+These are the real registered commands — see [the acc CLI command set](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts).
+
+If you keep an `af.config.json` in your project, here is how Spheron's configuration maps onto it:
 
 **Spheron config (via dashboard):**
 - Framework: Auto-detected
@@ -86,6 +92,8 @@ The `acc sites init` command creates an `af.config.json` file. Here is how Spher
   ]
 }
 ```
+
+> **What this maps to in code:** these fields are the [`af.config` schema](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts).
 
 ### From Spheron SDK to AF SDK
 
@@ -115,32 +123,37 @@ const af = new AlternateFuturesSdk({
   }),
 });
 
-// Upload to IPFS
-const result = await af.ipfs().add('./dist');
-console.log('CID:', result.pin.cid);
-console.log('URL:', `https://ipfs.io/ipfs/${result.pin.cid}`);
+// Upload a directory to IPFS
+const [result] = await af.ipfs().addFromPath('./dist');
+console.log('CID:', result.cid.toString());
+console.log('URL:', `https://ipfs.io/ipfs/${result.cid.toString()}`);
 ```
+
+> **What this maps to in code:** `addFromPath` returns a `UploadResult[]` of `{ cid, size, path }` — see the [IPFS client return shape (UploadResult)](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipfs.ts).
 
 ### Storage Protocol Mapping
 
 If you were using specific storage protocols on Spheron, here is how they map:
 
-| Spheron Protocol | AF Equivalent | CLI Flag |
-|-----------------|---------------|----------|
-| `ProtocolEnum.IPFS` | IPFS (default) | `acc sites deploy` |
-| `ProtocolEnum.FILECOIN` | Filecoin | `acc sites deploy --filecoin` |
-| `ProtocolEnum.ARWEAVE` | Arweave | `acc sites deploy --arweave` |
+| Spheron Protocol | Alternate Clouds equivalent | How to target it |
+|-----------------|-----------------------------|------------------|
+| `ProtocolEnum.IPFS` | IPFS (default) | Deployed by default |
+| `ProtocolEnum.FILECOIN` | Filecoin | Dashboard / SDK (no CLI flag yet) |
+| `ProtocolEnum.ARWEAVE` | Arweave | Dashboard / SDK (no CLI flag yet) |
+
+::: info Storage targeting
+A per-deploy `--filecoin` / `--arweave` CLI flag is not available yet. Choose the storage network from the dashboard or via the SDK.
+:::
 
 ## Step 2: Migrate IPFS Content
 
 If you have content pinned on Spheron's IPFS infrastructure, re-pin it on Alternate Futures before Spheron's pinning service goes offline.
 
-```bash
-# If you have the original files, re-upload them
-acc storage add ./my-files
+There is no direct `acc` storage command today — re-pin through the SDK:
 
-# Upload a directory to IPFS
-acc ipfs add ./my-content
+```typescript
+const results = await af.ipfs().addFromPath('./my-content');
+console.log('CID:', results[0].cid.toString());
 ```
 
 Your CIDs will remain the same since IPFS content-addressing is deterministic -- the same files always produce the same CID.
@@ -154,8 +167,8 @@ Arweave content is permanently stored on-chain, so it does not need to be re-upl
 # Access via any Arweave gateway:
 # https://arweave.net/{TX_ID}
 
-# Deploy new content to Arweave via AF
-acc sites deploy --arweave
+# Target Arweave for new content from the dashboard or SDK
+# (no per-deploy CLI flag yet)
 ```
 
 ## Step 3: Migrate Custom Domains
@@ -179,13 +192,9 @@ dig yourdomain.com TXT
 
 ### Configure Domains on Alternate Futures
 
-```bash
-# Add your domain to your AF site
-acc domains create --siteSlug my-site --hostname yourdomain.com
-
-# Get the required DNS records
-acc domains detail --hostname yourdomain.com
-```
+::: info Where to configure domains
+Add custom domains from the [Alternate Clouds dashboard](https://app.alternatefutures.ai) (a CLI `domains` command is not yet available). The dashboard shows the exact DNS records to set at your registrar.
+:::
 
 ### Update DNS Records
 
@@ -203,14 +212,11 @@ TTL: 3600
 ```
 Type: A
 Name: @
-Value: [Platform IP from acc domains detail]
+Value: [Platform IP shown in the dashboard]
 TTL: 3600
 ```
 
-```bash
-# Verify DNS configuration
-acc domains verify --hostname yourdomain.com
-```
+The dashboard reports verification status once your DNS records propagate.
 
 See the [Custom Domains guide](./custom-domains.md) for full details.
 
@@ -247,7 +253,7 @@ jobs:
         run: npm run build
 
       - name: Deploy
-        run: npx @alternatefutures/cli sites deploy
+        run: npx @alternatefutures/cli services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN }}
           AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID }}
@@ -256,7 +262,7 @@ jobs:
 ### Add Secrets
 
 1. Go to your GitHub repository **Settings** > **Secrets and variables** > **Actions**
-2. Add `AF_TOKEN` -- your personal access token (create one with `acc pat create --name "CI/CD"`)
+2. Add `AF_TOKEN` -- your personal access token (create one with [`acc pat create`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/pat/index.ts) `--name "CI/CD"`)
 3. Add `AF_PROJECT_ID` -- your project ID (find it with `acc projects list`)
 
 ## Step 5: Migrate Environment Variables
@@ -287,11 +293,11 @@ If your Spheron project used environment variables:
 Beyond replacing Spheron's hosting functionality, Alternate Futures provides additional features:
 
 - **AI agent deployment** -- Deploy Eliza chatbots, ComfyUI image generators, and custom agents
-- **Cloud functions** -- Serverless edge functions with optional SGX encryption
+- **Cloud functions** -- Serverless functions (confidential-compute options where available)
 - **Observability** -- OpenTelemetry-based APM with distributed tracing, metrics, and logging
 - **ENS integration** -- Full ENS domain support with `.eth` names
 - **IPNS records** -- Mutable pointers for stable URLs to changing content
-- **Private gateways** -- Dedicated IPFS gateways with custom domains
+- **Private gateways** -- Dedicated IPFS gateways with custom domains (via the SDK)
 - **Decentralized container registry** -- Self-hosted Docker registry on Akash
 - **Multi-method auth** -- Email, social OAuth, Web3 wallets (SIWE)
 
@@ -301,11 +307,11 @@ Beyond replacing Spheron's hosting functionality, Alternate Futures provides add
 |-----------------|------------------------------|
 | Dashboard deployments | CLI + SDK (web dashboard coming soon) |
 | GitHub auto-deploy | [CI/CD Integration](./cicd.md) with GitHub Actions |
-| IPFS pinning | Built-in IPFS pinning with `acc storage add` |
-| Arweave uploads | `acc sites deploy --arweave` |
-| Filecoin storage | `acc sites deploy --filecoin` |
+| IPFS pinning | Built-in IPFS pinning (SDK `af.ipfs().addFromPath()`) |
+| Arweave uploads | Arweave storage (dashboard / SDK) |
+| Filecoin storage | Filecoin storage (dashboard / SDK) |
 | Custom domains | [Custom Domains](./custom-domains.md) with SSL |
-| Preview deployments | Every deployment gets a unique CID URL |
+| Preview deployments | Each deployment is content-addressed on IPFS |
 | Team collaboration | [Projects](./projects.md) with team management |
 
 ## Troubleshooting

--- a/docs/guides/migrate-from-vercel.md
+++ b/docs/guides/migrate-from-vercel.md
@@ -4,7 +4,7 @@ description: Move your static sites and serverless functions from Vercel to Alte
 
 # Migrate from Vercel
 
-Move your static sites from Vercel to Alternate Futures for decentralized hosting with IPFS, Filecoin, and Arweave storage options.
+Move your static sites from Vercel onto Alternate Clouds — decentralized hosting from Alternate Futures with IPFS, Filecoin, and Arweave storage.
 
 **Time to complete:** 15-30 minutes per site
 
@@ -15,7 +15,7 @@ Move your static sites from Vercel to Alternate Futures for decentralized hostin
 | **Hosting model** | Centralized (AWS) | Decentralized (IPFS/Arweave/Filecoin) |
 | **Censorship resistance** | No | Yes |
 | **Permanent storage** | No | Yes (Arweave) |
-| **Free tier** | Limited (Hobby) | Generous free tier |
+| **Free tier** | Limited (Hobby) | Free tier available (see pricing) |
 | **Vendor lock-in** | Yes (Vercel-specific features) | No (standard IPFS/web protocols) |
 | **Crypto payments** | No | Yes (ETH, AR, FIL, SOL) |
 | **AI agents** | No | Yes |
@@ -34,12 +34,16 @@ Migrating from Vercel works best for **static sites** and **static exports** (Ne
 ## Step 1: Install and Authenticate
 
 ```bash
-# Install the Alternate Futures CLI
+# Install the Alternate Clouds CLI
 npm install -g @alternatefutures/cli
 
 # Authenticate
 acc login
 ```
+
+::: warning CLI binary name
+Commands here use `acc`. If your installed version still exposes the legacy `af` binary, update to the latest `@alternatefutures/cli` or substitute `af` for `acc`.
+:::
 
 ## Step 2: Configure Your Build
 
@@ -64,16 +68,24 @@ Build and deploy:
 
 ```bash
 npm run build
-acc sites init          # Set output directory to ./out
-acc sites deploy
+
+# Create a service (choose a starter template; set output dir to ./out)
+acc services create
+
+# Deploy it — pass the service id, or omit to pick interactively
+acc services deploy [id]
 ```
+
+These are the real registered commands — see [the acc CLI command set](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts).
 
 ### React (Vite or Create React App)
 
 ```bash
 npm run build
-acc sites init          # Set output directory to ./dist (Vite) or ./build (CRA)
-acc sites deploy
+
+# Set output dir to ./dist (Vite) or ./build (CRA) when prompted
+acc services create
+acc services deploy [id]
 ```
 
 ### Other Frameworks
@@ -100,13 +112,9 @@ Any framework that produces static output works. Set the correct output director
 
 ### Add Domain to Alternate Futures
 
-```bash
-# Add the domain to your site
-acc domains create --siteSlug my-site --hostname example.com
-
-# Get the required DNS records
-acc domains detail --hostname example.com
-```
+::: info Where to configure domains
+Add custom domains from the [Alternate Clouds dashboard](https://app.alternatefutures.ai) (a CLI `domains` command is not yet available). The dashboard shows the exact DNS records to set at your registrar.
+:::
 
 ### Update DNS Records
 
@@ -123,13 +131,10 @@ Value: cname.alternatefutures.ai
 ```
 Type: A
 Name: @
-Value: [IP from acc domains detail]
+Value: [IP shown in the dashboard]
 ```
 
-```bash
-# Verify DNS configuration
-acc domains verify --hostname example.com
-```
+The dashboard reports verification status once your DNS records propagate.
 
 ## Step 4: Migrate CI/CD
 
@@ -164,7 +169,7 @@ jobs:
         run: npm run build
 
       - name: Deploy
-        run: npx @alternatefutures/cli sites deploy
+        run: npx @alternatefutures/cli services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN }}
           AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID }}
@@ -173,7 +178,7 @@ jobs:
 ### Add Secrets
 
 1. Go to your GitHub repository **Settings** > **Secrets and variables** > **Actions**
-2. Add `AF_TOKEN` -- your personal access token (create one with `acc pat create --name "CI/CD"`)
+2. Add `AF_TOKEN` -- your personal access token (create one with [`acc pat create`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/pat/index.ts) `--name "CI/CD"`)
 3. Add `AF_PROJECT_ID` -- your project ID (find it with `acc projects list`)
 
 ## Step 5: Migrate Environment Variables
@@ -195,12 +200,12 @@ If your Vercel project uses environment variables:
 
 | Vercel Feature | Alternate Futures Equivalent |
 |----------------|------------------------------|
-| Preview deployments | Every deployment gets a unique CID URL |
-| Serverless functions | [Cloud Functions](./functions.md) with SGX encryption |
-| Edge functions | Cloud Functions (edge deployment) |
+| Preview deployments | Each deployment is content-addressed on IPFS |
+| Serverless functions | [Cloud Functions](./functions.md) (confidential-compute options where available) |
+| Edge functions | [Cloud Functions](./functions.md) |
 | Analytics | [Observability & APM](./observability.md) |
 | Image optimization | Build-time optimization (recommended) |
-| ISR/SSR | Static export + Cloud Functions for dynamic routes |
+| ISR/SSR | Static export; dynamic routes via [Cloud Functions](./functions.md) where available |
 | Cron jobs | Cloud Functions with external scheduling |
 
 ## Next Steps

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -4,7 +4,7 @@ description: Monitor your deployments with distributed tracing, metrics, and log
 
 # Observability & APM
 
-Monitor your applications with distributed tracing, metrics, and logging. The Alternate Futures Observability platform provides full APM (Application Performance Monitoring) capabilities for your deployed services.
+Instrument your services once, then query traces, metrics, and logs from the Alternate Clouds observability platform — full APM (Application Performance Monitoring) built on OpenTelemetry.
 
 ## Overview
 
@@ -18,7 +18,7 @@ The observability platform enables you to:
 
 ## Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │                     Your Applications                            │
 │  (AF Functions, Node.js, Python, Go, etc.)                      │
@@ -43,7 +43,7 @@ The observability platform enables you to:
            │
            ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│              Query via SDK, CLI, or GraphQL API                  │
+│              Query via SDK or GraphQL API                        │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -97,6 +97,10 @@ That's it! Your application is now sending traces, metrics, and logs to the Alte
 ---
 
 ## Instrumentation Setup
+
+::: tip What this maps to in code
+`initInstrumentation` and `withSpan` are real exports of the [SDK instrumentation module](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/instrumentation/index.ts), available via the `@alternatefutures/sdk/instrumentation` subpath.
+:::
 
 ### Node.js Auto-Instrumentation
 
@@ -250,6 +254,10 @@ logger.emit({
 
 ### Using the SDK
 
+::: tip What this maps to in code
+Every method below (`queryTraces`, `getTrace`, `queryLogs`, `queryMetrics`, `getServices`, `getSettings`, `updateSettings`, `getUsage`) is defined in the [observability SDK client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/observability.ts).
+:::
+
 ::: code-group
 
 ```typescript [Query Traces]
@@ -264,7 +272,7 @@ const af = new AlternateFuturesSdk({
 
 // Query traces from the last hour
 const traces = await af.observability().queryTraces({
-  projectId: 'prj_abc123',
+  projectId: process.env.AF_PROJECT_ID, // cuid, e.g. 'clx1a2b3c4d5e6f7g8h9'
   startTime: new Date(Date.now() - 60 * 60 * 1000),
   endTime: new Date(),
   serviceName: 'api-gateway',  // optional filter
@@ -285,7 +293,7 @@ traces.forEach(trace => {
 ```typescript [Get Trace Details]
 // Get full trace with all spans
 const trace = await af.observability().getTrace(
-  'prj_abc123',
+  process.env.AF_PROJECT_ID, // cuid
   'abc123def456...'
 );
 
@@ -310,12 +318,11 @@ trace.spans.forEach(span => {
 ```typescript [Query Logs]
 // Query logs with filters
 const logs = await af.observability().queryLogs({
-  projectId: 'prj_abc123',
+  projectId: process.env.AF_PROJECT_ID, // cuid, e.g. 'clx1a2b3c4d5e6f7g8h9'
   startTime: new Date(Date.now() - 24 * 60 * 60 * 1000),
   endTime: new Date(),
-  severityText: 'ERROR',         // Filter by severity
-  bodyContains: 'payment',       // Search in log body
-  serviceName: 'checkout-service',
+  severityText: 'ERROR',   // Filter by severity
+  search: 'payment',       // Full-text search in log body
   limit: 100,
 });
 
@@ -330,12 +337,12 @@ logs.forEach(log => {
 ```typescript [Query Metrics]
 // Query metrics with aggregation
 const metrics = await af.observability().queryMetrics({
-  projectId: 'prj_abc123',
+  projectId: process.env.AF_PROJECT_ID, // cuid, e.g. 'clx1a2b3c4d5e6f7g8h9'
   startTime: new Date(Date.now() - 60 * 60 * 1000),
   endTime: new Date(),
   metricName: 'http.server.duration',
-  aggregation: 'avg',
-  groupBy: ['http.route', 'http.status_code'],
+  aggregation: 'AVG',
+  interval: '1m',
 });
 
 metrics.forEach(series => {
@@ -350,7 +357,7 @@ metrics.forEach(series => {
 ```typescript [Service Statistics]
 // Get service-level statistics
 const services = await af.observability().getServices(
-  'prj_abc123',
+  process.env.AF_PROJECT_ID, // cuid
   new Date(Date.now() - 24 * 60 * 60 * 1000),
   new Date()
 );
@@ -375,133 +382,13 @@ services.forEach(service => {
 
 :::
 
-### Using the CLI
+### Querying via GraphQL
 
-::: code-group
-
-```bash [List Traces]
-# List recent traces
-acc observability traces
-
-# Filter by service
-acc observability traces --service api-gateway
-
-# Filter by status (errors only)
-acc observability traces --status ERROR
-
-# Filter by duration (slow requests)
-acc observability traces --min-duration 500
-
-# Look back further in time
-acc observability traces --hours 24 --limit 100
-```
-
-```bash [Get Trace Details]
-# View specific trace
-acc observability trace abc123def456...
-
-# Output shows:
-# Trace Details:
-#   Trace ID:    abc123def456...
-#   Service:     api-gateway
-#   Duration:    234.56ms
-#   Span Count:  12
-#   Has Error:   No
-#   Start Time:  12/29/2025, 10:30:15 AM
-#
-# Spans:
-# ┌────────────────────────────┬────────┬────────────┬────────┬──────────────┐
-# │ Span Name                  │ Kind   │ Duration   │ Status │ Service      │
-# ├────────────────────────────┼────────┼────────────┼────────┼──────────────┤
-# │ HTTP GET /api/users        │ SERVER │ 234.56ms   │ OK     │ api-gateway  │
-# │ PostgreSQL SELECT          │ CLIENT │ 45.23ms    │ OK     │ api-gateway  │
-# │ Redis GET                  │ CLIENT │ 2.34ms     │ OK     │ api-gateway  │
-# └────────────────────────────┴────────┴────────────┴────────┴──────────────┘
-```
-
-```bash [Query Logs]
-# Recent logs
-acc observability logs
-
-# Filter by severity
-acc observability logs --severity ERROR
-acc observability logs --severity WARN
-
-# Search in log body
-acc observability logs --search "connection failed"
-
-# Filter by service
-acc observability logs --service database-worker
-
-# Combine filters
-acc observability logs \
-  --service checkout-service \
-  --severity ERROR \
-  --hours 4
-```
-
-```bash [Service Statistics]
-# Get service performance overview
-acc observability services
-
-# Look at last 7 days
-acc observability services --hours 168
-
-# Output shows:
-# Found 5 service(s) with telemetry data:
-#
-# ┌────────────────────┬─────────┬──────────┬────────┬────────────┬──────────┬──────────┬──────────┬──────────┐
-# │ Service            │ Traces  │ Spans    │ Errors │ Error Rate │ Avg (ms) │ P50 (ms) │ P95 (ms) │ P99 (ms) │
-# ├────────────────────┼─────────┼──────────┼────────┼────────────┼──────────┼──────────┼──────────┼──────────┤
-# │ api-gateway        │ 15,234  │ 45,702   │ 123    │ 0.3%       │ 45.23    │ 32.10    │ 156.78   │ 423.45   │
-# │ user-service       │ 8,456   │ 16,912   │ 45     │ 0.3%       │ 23.45    │ 18.90    │ 67.89    │ 145.67   │
-# │ checkout-service   │ 3,234   │ 12,936   │ 234    │ 1.8%       │ 156.78   │ 123.45   │ 456.78   │ 890.12   │
-# │ notification-svc   │ 12,345  │ 24,690   │ 12     │ 0.0%       │ 12.34    │ 10.00    │ 34.56    │ 67.89    │
-# │ analytics-worker   │ 1,234   │ 3,702    │ 0      │ 0.0%       │ 234.56   │ 200.00   │ 567.89   │ 890.12   │
-# └────────────────────┴─────────┴──────────┴────────┴────────────┴──────────┴──────────┴──────────┴──────────┘
-```
-
-```bash [Check Usage & Cost]
-# View telemetry usage for billing period
-acc observability usage
-
-# Look at specific period
-acc observability usage --days 7
-
-# Output shows:
-# Telemetry Usage Summary:
-#
-#   Period:         12/1/2025 - 12/29/2025
-#   Project ID:     prj_abc123
-#
-# ┌───────────────────────┬───────────────────┐
-# │ Metric                │ Value             │
-# ├───────────────────────┼───────────────────┤
-# │ Spans Ingested        │ 1,234,567         │
-# │ Metrics Ingested      │ 456,789           │
-# │ Logs Ingested         │ 789,012           │
-# │ Total Data Ingested   │ 2.34 GB           │
-# │ Estimated Cost        │ $0.82             │
-# └───────────────────────┴───────────────────┘
-#
-# Pricing: $0.35 per GB ingested
-```
-
-```bash [View/Update Settings]
-# View current settings
-acc observability settings
-
-# Enable/disable telemetry types
-acc observability settings:update --traces true --metrics false
-
-# Adjust sampling rate (0.0 to 1.0)
-acc observability settings:update --sample-rate 0.5
-
-# Change retention periods
-acc observability settings:update --trace-retention 14 --log-retention 30
-```
-
+::: info CLI support is on the roadmap
+There is no `acc observability` command yet. Query observability data through the SDK (`af.observability()`) or the GraphQL API. The relevant types (`ObservabilitySettings`, `TelemetryUsageSummary`) and operations (`observabilitySettings`, `telemetryUsage`, `updateObservabilitySettings`) are defined in the [observability GraphQL schema](https://github.com/alternatefutures/service-cloud-api/blob/main/src/schema/typeDefs.ts).
 :::
+
+<!-- Fabricated `acc observability ...` CLI code-group removed: no such command exists. -->
 
 ---
 
@@ -513,7 +400,7 @@ Configure per-project observability settings:
 
 ```typescript [SDK]
 // Get current settings
-const settings = await af.observability().getSettings('prj_abc123');
+const settings = await af.observability().getSettings(process.env.AF_PROJECT_ID);
 
 console.log('Observability Settings:');
 console.log(`  Traces: ${settings.tracesEnabled ? 'Enabled' : 'Disabled'}`);
@@ -525,7 +412,7 @@ console.log(`  Metric Retention: ${settings.metricRetention} days`);
 console.log(`  Log Retention: ${settings.logRetention} days`);
 
 // Update settings
-await af.observability().updateSettings('prj_abc123', {
+await af.observability().updateSettings(process.env.AF_PROJECT_ID, {
   tracesEnabled: true,
   metricsEnabled: true,
   logsEnabled: true,
@@ -535,14 +422,15 @@ await af.observability().updateSettings('prj_abc123', {
 });
 ```
 
-```bash [CLI]
-# View settings
-acc observability settings
-
-# Update individual settings
-acc observability settings:update --sample-rate 0.5
-acc observability settings:update --trace-retention 14
-acc observability settings:update --logs false
+```graphql [GraphQL]
+# Read via observabilitySettings, write via updateObservabilitySettings
+mutation {
+  updateObservabilitySettings(input: { sampleRate: 0.5, traceRetention: 14, logsEnabled: false }) {
+    sampleRate
+    traceRetention
+    logsEnabled
+  }
+}
 ```
 
 :::
@@ -614,11 +502,15 @@ export default async function handler(request) {
 
 ## Pricing
 
+::: warning Illustrative pricing
+The rate below is an example for cost modeling, not a committed price. The API returns actual cost via `TelemetryUsageSummary` (`costCents` / `costFormatted`); confirm current rates with your plan.
+:::
+
 Observability is billed based on data ingested:
 
-| Metric | Price |
+| Metric | Example rate |
 |--------|-------|
-| Data Ingestion | **$0.35 per GB** |
+| Data Ingestion | ~$0.35 per GB |
 
 Includes:
 - Traces, metrics, and logs
@@ -628,10 +520,11 @@ Includes:
 
 ### Estimating Costs
 
-Use the CLI to check current usage:
+Check current usage via the SDK:
 
-```bash
-acc observability usage --days 30
+```typescript
+const usage = await af.observability().getUsage(process.env.AF_PROJECT_ID);
+console.log(usage.costFormatted);
 ```
 
 **Typical data sizes:**
@@ -652,7 +545,7 @@ acc observability usage --days 30
 ```typescript
 // Configure sampling
 await initInstrumentation({
-  projectId: 'prj_abc123',
+  projectId: process.env.AF_PROJECT_ID, // cuid, e.g. 'clx1a2b3c4d5e6f7g8h9'
   projectSlug: 'my-project',
   serviceName: 'high-volume-service',
   instrumentationConfig: {
@@ -664,7 +557,7 @@ await initInstrumentation({
 });
 
 // Or set sampling via settings
-await af.observability().updateSettings('prj_abc123', {
+await af.observability().updateSettings(process.env.AF_PROJECT_ID, {
   sampleRate: 0.1, // Only sample 10%
 });
 ```
@@ -762,9 +655,6 @@ const response = await fetch('https://other-service/api', {
 4. **Review settings** - Telemetry type might be disabled
 
 ```bash
-# Check settings
-acc observability settings
-
 # Verify connectivity
 curl -X POST https://otel.alternatefutures.ai/v1/traces \
   -H "Content-Type: application/json" \
@@ -808,4 +698,4 @@ span.setAttribute('user.tier', 'premium');
 - [Cloud Functions](./functions.md) - Deploy serverless functions with built-in observability
 - [Best Practices](./best-practices.md) - General platform best practices
 - [Billing](./billing.md) - Understand billing and manage costs
-- [CLI Commands](/cli/commands.md) - Full CLI reference
+- [SDK API](../sdk/api.md) - Query observability data programmatically

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -84,10 +84,7 @@ acc projects switch
 # You'll be prompted to select which project to use
 
 # Or specify directly
-acc projects switch --project-id <project-id>
-
-# Check current project
-acc projects current
+acc projects switch <project-id>
 ```
 
 ```typescript [SDK]
@@ -117,21 +114,15 @@ Configure project basics:
 
 ### Storage Settings
 
-Configure backup storage:
+::: info What this maps to in code
+- **CLI:** [projects command](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/projects/index.ts) — `list`, `create`, `update` (rename only), `switch`, `delete`.
+- **SDK:** [projects client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/projects.ts) — backup toggles via `update({ where, data: { backupStorageOnArweave, backupStorageOnFilecoin } })`.
+- **API:** [Project data model](https://github.com/alternatefutures/service-cloud-api/blob/main/prisma/schema.prisma).
+:::
+
+Backup storage is configured through the SDK. The CLI `acc projects update` only renames a project.
 
 ::: code-group
-
-```bash [CLI]
-# Enable Arweave backup
-acc projects update \
-  --project-id <project-id> \
-  --backup-arweave true
-
-# Enable Filecoin backup
-acc projects update \
-  --project-id <project-id> \
-  --backup-filecoin true
-```
 
 ```typescript [SDK]
 // Update project settings
@@ -211,13 +202,13 @@ deploy-staging:
   env:
     AF_PROJECT_ID: ${{ secrets.STAGING_PROJECT_ID }}
   steps:
-    - run: acc sites deploy
+    - run: acc services deploy
 
 deploy-production:
   env:
     AF_PROJECT_ID: ${{ secrets.PROD_PROJECT_ID }}
   steps:
-    - run: acc sites deploy
+    - run: acc services deploy
 ```
 
 ## Team Collaboration
@@ -233,71 +224,42 @@ Projects support team collaboration (feature coming soon):
 
 View all resources in a project:
 
-### Sites
+### Services
 ```bash
-acc sites list --project-id <project-id>
+acc services list
 ```
 
-### Functions
+### Deployments
 ```bash
-acc functions list --project-id <project-id>
-```
-
-### Storage
-```bash
-acc storage list --project-id <project-id>
-```
-
-### Domains
-```bash
-acc domains list --project-id <project-id>
+acc deployments list --project <project-id>
 ```
 
 ## Project Limits
 
-Each project includes:
-
-| Resource | Free Tier | Pro Tier |
-|----------|-----------|----------|
-| **Sites** | 10 | Unlimited |
-| **Functions** | 5 | Unlimited |
-| **Storage** | 10 GB | 100 GB+ |
-| **Bandwidth** | 100 GB/mo | 1 TB/mo+ |
-| **Custom Domains** | 3 | Unlimited |
-| **Team Members** | 1 | 10+ |
+Resource limits depend on your plan. Check your current account with `acc billing balance`. Specific per-tier limits are intentionally not listed here to avoid publishing numbers that may be out of date.
 
 ## Billing
 
-Each project has independent billing:
-
-- Separate usage tracking
-- Individual payment methods
-- Per-project invoices
-- Custom limits and budgets
+Billing today uses a single credit balance for your account. Per-project invoices, separate payment methods, and per-project budgets are not yet available.
 
 Access billing:
 ```bash
-# View project billing (coming soon)
-acc billing status --project-id <project-id>
+# View your credit balance
+acc billing balance
 ```
 
 ## Migrating Between Projects
 
 Move resources between projects:
 
-### Export Configuration
+### Move a service to another project
 ```bash
-# Export site configuration
-acc sites export --site-id <site-id> > site-config.json
-```
+# Switch to the target project
+acc projects switch <target-project-id>
 
-### Import to New Project
-```bash
-# Switch to target project
-acc projects switch --project-id <target-project-id>
-
-# Create new site from config
-acc sites create --config site-config.json
+# Recreate the service from a template, then deploy
+acc services create
+acc services deploy
 ```
 
 ## Project API Access
@@ -305,14 +267,11 @@ acc sites create --config site-config.json
 Each project can have dedicated API keys:
 
 ```bash
-# Create project-scoped API key
-acc pat create \
-  --name "Project API Key" \
-  --project-id <project-id> \
-  --permissions read,write
+# Create a personal access token
+acc pat create --name "Project API Key"
 
-# Use in applications
-export AF_TOKEN=<project-api-key>
+# Use in applications (scope to a project via AF_PROJECT_ID)
+export AF_TOKEN=<personal-access-token>
 export AF_PROJECT_ID=<project-id>
 ```
 
@@ -421,9 +380,8 @@ Set project context via environment variables:
 export AF_PROJECT_ID=<project-id>
 
 # All CLI commands use this project
-acc sites list
-acc functions deploy
-acc storage upload
+acc services list
+acc deployments list
 ```
 
 In CI/CD:
@@ -441,13 +399,10 @@ env:
 
 **Solution:**
 ```bash
-# Check current project
-acc projects current
+# Switch to the correct project
+acc projects switch <correct-id>
 
-# Switch to correct project
-acc projects switch --project-id <correct-id>
-
-# Or set explicitly
+# Or set it explicitly for the session
 export AF_PROJECT_ID=<correct-id>
 ```
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -35,7 +35,7 @@ Before you begin, make sure you have:
 The web application is currently in development. In the meantime, you can use the CLI or SDK to access the full platform.
 :::
 
-## Installation
+## Step 1: Install the CLI
 
 ::: code-group
 
@@ -80,7 +80,7 @@ If you prefer tokens or need to automate deployments:
 
 1. Log in via the CLI first: `acc login`
 2. Create a Personal Access Token: `acc pat create --name "My Development Token"`
-3. Copy the token (it starts with `pat_...`)
+3. Copy the token (it starts with `af_`, e.g. `af_prod_...` — see [`token.service.ts`](https://github.com/alternatefutures/service-auth/blob/main/src/services/token.service.ts))
 4. Note your project ID from `acc projects list`
 5. Set them as environment variables:
 
@@ -88,12 +88,12 @@ If you prefer tokens or need to automate deployments:
 
 ```bash [CLI]
 # Set environment variables
-export AF_TOKEN=pat_your_token_here
-export AF_PROJECT_ID=prj_your_project_id
+export AF_TOKEN=af_prod_your_token_here
+export AF_PROJECT_ID=clabc123yourprojectid
 
 # Or add to your .bashrc/.zshrc for persistence
-echo 'export AF_TOKEN=pat_your_token_here' >> ~/.bashrc
-echo 'export AF_PROJECT_ID=prj_your_project_id' >> ~/.bashrc
+echo 'export AF_TOKEN=af_prod_your_token_here' >> ~/.bashrc
+echo 'export AF_PROJECT_ID=clabc123yourprojectid' >> ~/.bashrc
 ```
 
 ```typescript [SDK]
@@ -119,8 +119,8 @@ Environment variables store sensitive information (like tokens) outside your cod
 **How to use them:**
 1. Store your token in a `.env` file:
    ```bash
-   AF_TOKEN=pat_your_token_here
-   AF_PROJECT_ID=prj_your_project_id
+   AF_TOKEN=af_prod_your_token_here
+   AF_PROJECT_ID=clabc123yourprojectid
    ```
 2. Add `.env` to your `.gitignore` file so Git doesn't track it
 3. Your code reads from `process.env.AF_TOKEN` instead of hardcoding the key
@@ -150,7 +150,7 @@ Environment variables store sensitive information (like tokens) outside your cod
 - Make sure you have an account at [https://app.alternatefutures.ai](https://app.alternatefutures.ai)
 
 **"Invalid token"**
-- Double-check you copied the entire token (starts with `pat_`)
+- Double-check you copied the entire token (starts with `af_`)
 - Make sure there are no extra spaces
 - Generate a new token if needed: `acc pat create --name "New Token"`
 
@@ -178,7 +178,7 @@ We provide ready-to-deploy templates for popular frameworks. Choose one that fit
 
 ```bash
 # Clone the React template
-git clone https://github.com/alternatefutures/template-react my-site
+git clone https://github.com/alternatefutures/template-cloud-react my-site
 cd my-site
 
 # Install dependencies
@@ -187,18 +187,18 @@ npm install
 # Build for production
 npm run build
 
-# Initialize and deploy (build output is in ./dist)
-acc sites init
-acc sites deploy
+# Create a service and deploy (build output is in ./dist)
+acc services create
+acc services deploy
 ```
 
-[Template Repository](https://github.com/alternatefutures/template-react) | [React Docs](https://react.dev/) | [Vite Docs](https://vitejs.dev/)
+[Template Repository](https://github.com/alternatefutures/template-cloud-react) | [React Docs](https://react.dev/) | [Vite Docs](https://vitejs.dev/)
 
 **Next.js (Static Export)**
 
 ```bash
 # Clone the Next.js template
-git clone https://github.com/alternatefutures/template-nextjs my-site
+git clone https://github.com/alternatefutures/template-cloud-nextjs my-site
 cd my-site
 
 # Install dependencies
@@ -207,18 +207,18 @@ npm install
 # Build static export
 npm run build
 
-# Initialize and deploy (build output is in ./out)
-acc sites init
-acc sites deploy
+# Create a service and deploy (build output is in ./out)
+acc services create
+acc services deploy
 ```
 
-[Template Repository](https://github.com/alternatefutures/template-nextjs) | [Next.js Docs](https://nextjs.org/docs)
+[Template Repository](https://github.com/alternatefutures/template-cloud-nextjs) | [Next.js Docs](https://nextjs.org/docs)
 
 **Vue.js (Vite)**
 
 ```bash
 # Clone the Vue template
-git clone https://github.com/alternatefutures/template-vue my-site
+git clone https://github.com/alternatefutures/template-cloud-vue my-site
 cd my-site
 
 # Install dependencies
@@ -227,18 +227,18 @@ npm install
 # Build for production
 npm run build
 
-# Initialize and deploy (build output is in ./dist)
-acc sites init
-acc sites deploy
+# Create a service and deploy (build output is in ./dist)
+acc services create
+acc services deploy
 ```
 
-[Template Repository](https://github.com/alternatefutures/template-vue) | [Vue.js Docs](https://vuejs.org/guide/) | [Vite Docs](https://vitejs.dev/)
+[Template Repository](https://github.com/alternatefutures/template-cloud-vue) | [Vue.js Docs](https://vuejs.org/guide/) | [Vite Docs](https://vitejs.dev/)
 
 **Astro**
 
 ```bash
 # Clone the Astro template
-git clone https://github.com/alternatefutures/template-astro my-site
+git clone https://github.com/alternatefutures/template-cloud-astro my-site
 cd my-site
 
 # Install dependencies
@@ -247,69 +247,29 @@ npm install
 # Build for production
 npm run build
 
-# Initialize and deploy (build output is in ./dist)
-acc sites init
-acc sites deploy
+# Create a service and deploy (build output is in ./dist)
+acc services create
+acc services deploy
 ```
 
-[Template Repository](https://github.com/alternatefutures/template-astro) | [Astro Docs](https://docs.astro.build/)
-
-**SvelteKit (Static Adapter)**
-
-```bash
-# Clone the SvelteKit template
-git clone https://github.com/alternatefutures/template-sveltekit my-site
-cd my-site
-
-# Install dependencies
-npm install
-
-# Build static export
-npm run build
-
-# Initialize and deploy (build output is in ./build)
-acc sites init
-acc sites deploy
-```
-
-[Template Repository](https://github.com/alternatefutures/template-sveltekit) | [SvelteKit Docs](https://kit.svelte.dev/docs)
+[Template Repository](https://github.com/alternatefutures/template-cloud-astro) | [Astro Docs](https://docs.astro.build/)
 
 **Hugo (Static Site Generator)**
 
 ```bash
 # Clone the Hugo template
-git clone https://github.com/alternatefutures/template-hugo my-site
+git clone https://github.com/alternatefutures/template-cloud-hugo my-site
 cd my-site
 
 # Build for production (requires Hugo installed)
 hugo
 
-# Initialize and deploy (build output is in ./public)
-acc sites init
-acc sites deploy
+# Create a service and deploy (build output is in ./public)
+acc services create
+acc services deploy
 ```
 
-[Template Repository](https://github.com/alternatefutures/template-hugo) | [Hugo Docs](https://gohugo.io/documentation/)
-
-**VitePress (Documentation)**
-
-```bash
-# Clone the VitePress template
-git clone https://github.com/alternatefutures/template-vitepress my-site
-cd my-site
-
-# Install dependencies
-npm install
-
-# Build for production
-npm run docs:build
-
-# Initialize and deploy (build output is in ./docs/.vitepress/dist)
-acc sites init
-acc sites deploy
-```
-
-[Template Repository](https://github.com/alternatefutures/template-vitepress) | [VitePress Docs](https://vitepress.dev/)
+[Template Repository](https://github.com/alternatefutures/template-cloud-hugo) | [Hugo Docs](https://gohugo.io/documentation/)
 
 ::: tip Framework Not Listed?
 Any static site generator works with Alternate Futures! Just build your site and deploy the output directory. Common output folders: `dist/`, `build/`, `out/`, `public/`.
@@ -377,7 +337,7 @@ Now let's deploy your site to a decentralized storage network. You have three op
 
 ```bash [CLI]
 # Initialize site configuration (creates af.config.json)
-acc sites init
+acc services create
 
 # Follow the prompts to configure:
 # - Site name
@@ -386,7 +346,7 @@ acc sites init
 # - Storage network (IPFS, Filecoin, Arweave)
 
 # Deploy the site
-acc sites deploy
+acc services deploy
 
 # You should see output like:
 # ✓ Building site...
@@ -407,9 +367,10 @@ const af = new AlternateFuturesSdk({
   }),
 });
 
-// Upload to IPFS
-const result = await af.ipfs().add('./dist');
-console.log('CID:', result.pin.cid);
+// Upload a build directory to IPFS
+const [result] = await af.ipfs().addFromPath('./dist');
+console.log('CID:', result.cid.toString());
+// ipfs client source: package-cloud-sdk/src/clients/ipfs.ts
 
 // List your sites
 const sites = await af.sites().list();
@@ -435,11 +396,11 @@ When you deployed, Alternate Futures:
 ::: code-group
 
 ```bash [CLI]
-# List all your sites
-acc sites list
+# List all your services
+acc services list
 
-# View deployments for a specific site
-acc sites deployments --slug my-site
+# View deployments for a specific service
+acc deployments --service my-site
 
 # Output shows:
 # - Site name and slug
@@ -473,7 +434,7 @@ sites.forEach(site => {
 **"No such file or directory: ./dist"**
 - Make sure the directory exists
 - Use the correct path to your build output
-- Try an absolute path: `acc sites deploy /full/path/to/dist --network ipfs`
+- Re-run the deploy from the correct directory: `acc services deploy`
 
 **"Deployment failed" or timeout errors**
 - Check your internet connection
@@ -539,7 +500,7 @@ Congratulations! You've deployed your first site to decentralized infrastructure
 
 ### Need Help?
 
-- **[Glossary](./glossary.md)** - Definitions of technical terms (coming soon)
+- **[Glossary](./glossary.md)** - Definitions of technical terms
 - **GitHub Issues** - [Report bugs or request features](https://github.com/alternatefutures)
 - **Community** - Join our [Discord](https://discord.gg/alternatefutures) or [Twitter](https://twitter.com/alternatefutures)
 

--- a/docs/guides/registry-architecture.md
+++ b/docs/guides/registry-architecture.md
@@ -4,11 +4,15 @@ description: Technical deep dive into the decentralized container registry archi
 
 # Registry Architecture
 
-Deep dive into the technical architecture of the decentralized container registry.
+::: warning Reference architecture
+This is a technical reference for a **self-hostable** decentralized registry built from open-source components (OpenRegistry, Kubo/IPFS, PostgreSQL) on Akash. It is not a description of a running, managed Alternate Futures service. Schemas, resource profiles, environment variables, endpoints, and JWT structures below are design guidance for your own deployment — verify each value against the upstream projects and your own SDL before relying on it.
+:::
+
+Deep dive into the technical architecture of a decentralized container registry you can run yourself.
 
 ## System Overview
 
-The Alternate Futures registry is a **fully decentralized** container registry built on open-source components running on Akash Network with IPFS storage.
+This registry is a **self-hostable, decentralized** container registry built on open-source components running on Akash Network with IPFS storage.
 
 ```
 ┌────────────────────────────────────────────────────────────┐
@@ -569,8 +573,8 @@ Use GeoDNS to route clients to nearest instance.
 
 ## Comparison with Centralized Registries
 
-| Feature | Docker Hub | Alternate Futures Registry |
-|---------|------------|----------------------------|
+| Feature | Docker Hub | Self-Hosted Decentralized Registry |
+|---------|------------|-------------------------------------|
 | **Storage** | Centralized S3 | Decentralized IPFS |
 | **Compute** | AWS/GCP | Akash Network |
 | **Control** | Docker, Inc. | You |

--- a/docs/guides/registry-deployment.md
+++ b/docs/guides/registry-deployment.md
@@ -4,6 +4,10 @@ description: Deploy your own OpenRegistry and IPFS container registry stack on A
 
 # Deploying the Decentralized Registry
 
+::: warning Self-hosting third-party components
+This guide deploys open-source components (OpenRegistry + Kubo/IPFS + PostgreSQL) on Akash. Alternate Futures does not publish a prebuilt registry SDL — you supply your own `deploy-registry.yaml` describing these services. Treat the commands and values below as a template to adapt, not a turnkey Alternate Futures deployment.
+:::
+
 This guide walks you through deploying your own OpenRegistry + IPFS stack on Akash Network.
 
 ## Prerequisites
@@ -112,12 +116,13 @@ akash query bank balances $AKASH_ACCOUNT_ADDRESS --node $AKASH_NODE
 
 ## Step 3: Configure Deployment
 
-### Download SDL File
+### Author Your SDL File
 
-Download the deployment configuration:
+There is no published `deploy-registry.yaml` to download. Create one locally that defines the three services (PostgreSQL, IPFS/Kubo, OpenRegistry) using the resource profiles and environment variables from the [Registry Architecture](/guides/registry-architecture) reference. Save it as `deploy-registry.yaml` in your working directory before continuing.
 
 ```bash
-curl -O https://raw.githubusercontent.com/alternatefutures/backend/main/deploy-registry.yaml
+# Create the file, then validate it before deploying:
+akash deployment validate deploy-registry.yaml
 ```
 
 ### Edit Configuration
@@ -559,7 +564,7 @@ akash provider lease-logs \
 ## Next Steps
 
 - [Use Your Registry](/guides/decentralized-registry) - Push and pull images
-- [CLI Integration](/cli/commands) - Add registry commands to CLI
+- **CLI support** - The `acc` CLI does not currently include registry commands; interact with your registry using the standard `docker` client and the OCI HTTP API.
 - **Monitoring** - Set up alerts and dashboards (guide coming soon)
 
 ## Support
@@ -568,4 +573,4 @@ Need help deploying?
 
 - [Discord Community](https://discord.gg/alternatefutures)
 - [Akash Discord](https://discord.gg/akash)
-- [GitHub Issues](https://github.com/alternatefutures/backend/issues)
+- [GitHub Issues](https://github.com/alternatefutures/service-cloud-api/issues)

--- a/docs/guides/sites.md
+++ b/docs/guides/sites.md
@@ -4,7 +4,7 @@ description: Deploy static sites to IPFS, Filecoin, or Arweave using the Alterna
 
 # Deploying Sites
 
-Deploy static sites to decentralized storage networks (IPFS, Filecoin, Arweave).
+Deploy static sites to Alternate Clouds and serve them from decentralized storage networks — IPFS, Filecoin, and Arweave. This guide covers the `acc` CLI flow available today and the web-app methods shipping soon.
 
 ## Deployment Methods
 
@@ -46,18 +46,21 @@ Deploy a local build folder:
 
 ### CLI Deployment (Available Now)
 
-Deploy via command line:
+Deployments are service-based. Create a service from a template, then deploy it:
 
 ```bash
-# Deploy to IPFS
-acc sites deploy ./dist --network ipfs
+# Create a service (interactive: pick a template and configure it)
+acc services create
 
-# Deploy to Arweave
-acc sites deploy ./dist --network arweave
+# Deploy the service by id
+acc services deploy <service-id>
 
-# Deploy to Filecoin
-acc sites deploy ./dist --network filecoin
+# List your deployments (add --all to include closed/older ones)
+acc deployments
+acc deployments --all
 ```
+
+> **What this maps to in code:** the CLI command surface is defined in [`cli.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts); the [`services` command (deploy/create/list)](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/services/index.ts) implements `acc services deploy [id]`. There is no `sites` command and no `--network` flag — storage network selection is not a CLI option.
 
 ## Storage Networks
 
@@ -323,28 +326,36 @@ Here's what different project sizes cost across networks:
 
 ## Build Configuration
 
-### Framework Detection
+### Output Directory by Framework
 
-Automatic detection for:
+Set `distDir` in your `af.config` to your framework's build output directory. Common defaults:
 
-- **React/Vite** - `dist/`
-- **Next.js** - `.next/`
-- **SvelteKit** - `.svelte-kit/output/client/`
-- **Nuxt** - `.output/public/`
-- **Astro** - `dist/`
-- **Hugo** - `public/`
+| Framework | Output directory |
+|-----------|------------------|
+| React / Vite | `dist` |
+| Next.js | `.next` |
+| SvelteKit | `.svelte-kit/output/client` |
+| Nuxt | `.output/public` |
+| Astro | `dist` |
+| Hugo | `public` |
 
-### Custom Build
+### Build Configuration
 
-Specify custom build settings:
+Configure your site in an `af.config.ts` (or `.js` / `.json`) file at the project root:
 
-```yaml
-build:
-  command: npm run build
-  output: dist
-  environment:
-    NODE_ENV: production
+```typescript
+export default {
+  sites: [
+    {
+      slug: 'my-site',
+      distDir: 'dist',
+      buildCommand: 'npm run build', // optional
+    },
+  ],
+};
 ```
+
+> **What this maps to in code:** the [af.config site configuration schema](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts) defines the supported keys — `slug`, `distDir`, and optional `buildCommand`. There is no `output`, `command`, or `environment` (env-var injection) support today.
 
 ## Custom Domains
 
@@ -368,7 +379,7 @@ See [Custom Domains](./custom-domains.md) for detailed instructions.
 ## Deployment History
 
 ::: warning Coming Soon
-Deployment history viewing via the web interface is in development. Use the CLI to view deployment history: `acc sites list --history`
+Deployment history viewing via the web interface is in development. In the meantime, list deployments from the CLI with `acc deployments --all` (filter with `--service <name>` or `--status <status>`).
 :::
 
 View all deployments for a site:
@@ -379,7 +390,7 @@ View all deployments for a site:
 - **Size** - Total deployment size
 - **Cost** - Deployment cost
 
-Roll back to any previous deployment with one click.
+> Rollback to a previous deployment is planned for the web app and is not yet available.
 
 ## Next Steps
 

--- a/docs/guides/storage.md
+++ b/docs/guides/storage.md
@@ -14,20 +14,9 @@ Manage decentralized storage across IPFS, Filecoin, and Arweave.
 
 Upload a file to decentralized storage in seconds:
 
-::: code-group
+Storage is managed through the SDK. (There is no `acc storage` or `acc ipfs` CLI command yet — the CLI surface is login/logout/projects/services/deployments/ssh/billing.)
 
-```bash [CLI]
-# Upload a file to IPFS
-acc storage add ./my-file.pdf
-
-# Upload an entire directory
-acc storage add ./my-folder
-
-# Upload directly to IPFS (returns CID)
-acc ipfs add ./my-file.pdf
-```
-
-```typescript [SDK]
+```typescript
 import { AlternateFuturesSdk, PersonalAccessTokenService } from '@alternatefutures/sdk/node';
 
 const af = new AlternateFuturesSdk({
@@ -37,23 +26,16 @@ const af = new AlternateFuturesSdk({
   }),
 });
 
-// Upload a file
-const result = await af.storage().uploadFile({
-  file: './my-file.pdf',
-});
-
-console.log('CID:', result.pin.cid);
-console.log('Size:', result.pin.size);
-
-// Upload a directory
+// Upload a directory (accepts a filesystem path)
 const dirResult = await af.storage().uploadDirectory({
   path: './my-folder',
 });
 
 console.log('Directory CID:', dirResult.pin.cid);
+console.log('Size:', dirResult.pin.size);
 ```
 
-:::
+> **What this maps to in code:** upload/list/get/delete are implemented in [`StorageClient`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/storage.ts); authentication uses [`PersonalAccessTokenService`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/libs/AccessTokenService/PersonalAccessTokenService.ts). The [CLI command surface](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts) does not include storage commands.
 
 ## Storage Networks
 
@@ -108,34 +90,27 @@ console.log('Directory CID:', dirResult.pin.cid);
 
 ## Uploading Files
 
-### Upload via CLI
-
-```bash
-# Upload a single file
-acc storage add ./report.pdf
-
-# Upload an entire directory
-acc storage add ./build-output
-
-# Upload directly to IPFS (lower level, returns raw CID)
-acc ipfs add ./my-image.png
-```
-
-When you upload, the file is pinned to IPFS and its CID (Content Identifier) is returned. The CID is a unique hash of the file content -- the same file always produces the same CID.
+When you upload, the content is pinned to IPFS and its CID (Content Identifier) is returned. The CID is a unique hash of the file content — the same content always produces the same CID. Uploads are performed through the SDK (see below); there is no `acc storage`/`acc ipfs` CLI command yet.
 
 ### Upload via SDK
 
+`uploadFile` takes a `FileLike` object (with a `name` and contents), not a path string. Construct one from your file contents; for a filesystem path, use `uploadDirectory({ path })`.
+
 ```typescript
-// Upload a single file
+import { readFile } from 'node:fs/promises';
+
+// Upload a single file (pass a File/FileLike, not a path)
+const bytes = await readFile('./report.pdf');
 const fileResult = await af.storage().uploadFile({
-  file: './report.pdf',
+  file: new File([bytes], 'report.pdf'),
 });
 
 console.log('File uploaded!');
 console.log('CID:', fileResult.pin.cid);
+console.log('Size:', fileResult.pin.size);
 console.log('URL:', `https://ipfs.io/ipfs/${fileResult.pin.cid}`);
 
-// Upload a directory (e.g., a built website)
+// Upload a directory (accepts a filesystem path)
 const dirResult = await af.storage().uploadDirectory({
   path: './dist',
 });
@@ -145,49 +120,33 @@ console.log('Directory CID:', dirResult.pin.cid);
 
 ## Listing Storage Items
 
-::: code-group
-
-```bash [CLI]
-# List all files in your project's storage
-acc storage list
-```
-
-```typescript [SDK]
+```typescript
 // List all storage items
 const items = await af.storage().list();
 
 items.forEach(item => {
-  console.log(`${item.name} (${item.cid})`);
-  console.log(`  Size: ${item.size}`);
-  console.log(`  Created: ${item.createdAt}`);
+  console.log(`${item.filename} (${item.cid})`);
+  console.log(`  Extension: ${item.extension}`);
+  if (item.arweaveId) console.log(`  Arweave: ${item.arweaveId}`);
 });
 ```
 
-:::
+> `list()` returns `StoragePin[]` with `cid`, `filename`, `extension`, `arweaveId`, and `filecoinDealIds`. File size and creation date are not returned by the SDK.
 
 ## Retrieving Files
 
-::: code-group
-
-```bash [CLI]
-# Retrieve a file by name
-acc storage get --name my-file.pdf
-
-# Retrieve a file by CID
-acc storage get --cid QmXxx...
-```
-
-```typescript [SDK]
-// Get file details by CID
+```typescript
+// Get storage-pin details by CID
 const file = await af.storage().get({ cid: 'QmXxx...' });
 
-console.log('Name:', file.name);
-console.log('Size:', file.size);
-console.log('Network:', file.network);
-console.log('URL:', file.url);
+console.log('Filename:', file.filename);
+console.log('Extension:', file.extension);
+console.log('Arweave ID:', file.arweaveId);
+// Build a gateway URL from the CID:
+console.log('URL:', `https://ipfs.io/ipfs/${file.cid}`);
 ```
 
-:::
+> `get({ cid })` returns a `StoragePin` (`cid`, `filename`, `extension`, `arweaveId`, `filecoinDealIds`). It does not include size, network, or a URL — construct the gateway URL yourself from `cid`.
 
 ### Accessing via IPFS Gateway
 
@@ -201,27 +160,17 @@ https://gateway.pinata.cloud/ipfs/<CID>
 For faster, branded access, use a [Private Gateway](/guides/gateways):
 
 ```
-https://your-gateway.af-gateways.app/ipfs/<CID>
+https://<gateway-slug>.<gateway-domain>/ipfs/<CID>
 ```
+
+> The exact gateway domain is not yet finalized in the published tooling; storage.md and gateways.md currently disagree (`af-gateways.app` vs `af-gateway.app`). Confirm the canonical host before relying on it.
 
 ## Deleting Files
 
-::: code-group
-
-```bash [CLI]
-# Delete a file by name
-acc storage delete --name my-file.pdf
-
-# Delete a file by CID
-acc storage delete --cid QmXxx...
-```
-
-```typescript [SDK]
-// Delete a storage item
+```typescript
+// Delete a storage item by CID
 await af.storage().delete({ cid: 'QmXxx...' });
 ```
-
-:::
 
 ::: warning
 Deleting a file unpins it from IPFS. The content may still be available on the network if other nodes have cached or pinned it, but it will no longer be guaranteed to be available.
@@ -237,33 +186,13 @@ Pinning keeps content available on IPFS by ensuring at least one node stores and
 
 ### Pin Providers
 
-We integrate with multiple pinning services for redundancy:
-
-- **Pinata** - Fast, reliable pinning
-- **Web3.Storage** - Free tier available
-- **Lighthouse** - Filecoin-backed pinning
-
-### Pin Status
-
-- **Pinned** - Content is actively pinned and available
-- **Unpinned** - Content may become unavailable
-- **Pinning** - Pin operation in progress
-- **Failed** - Pin operation failed (check logs)
+Pinning is handled by the platform's upload service. Provider selection and pin-status reporting are not exposed through the SDK today, so treat the specifics as an infrastructure detail rather than a configurable API.
 
 ## IPNS (Mutable Pointers)
 
 IPNS (InterPlanetary Name System) lets you create mutable pointers to IPFS content. This is useful when you want a stable URL that always points to the latest version of your content.
 
-```bash
-# Create an IPNS record
-acc ipns create --name my-website
-
-# Publish an IPFS hash to your IPNS name
-acc ipns publish --name my-website --hash QmNewHash...
-
-# Resolve an IPNS name to its current content
-acc ipns resolve k51qzi5uqu5...
-```
+IPNS is available through the SDK (`af.ipns()`); there is no `acc ipns` CLI command. See the [IPNS Guide](/guides/ipns) for the SDK method signatures.
 
 See the [IPNS Guide](/guides/ipns) for full details.
 
@@ -300,11 +229,11 @@ See [Billing](/guides/billing) for full pricing details.
 
 ### Upload Fails
 
-**Problem:** `acc storage add` returns an error
+**Problem:** `af.storage().uploadFile()` / `uploadDirectory()` returns an error
 
 **Solutions:**
-- Check that the file path is correct
-- Verify you are authenticated (`acc login`)
+- Confirm `uploadFile` is passed a `File`/`FileLike` (not a path string) and `uploadDirectory` a valid path
+- Verify your access token and project id are set correctly
 - Ensure you have sufficient storage quota
 - Check file size does not exceed limits
 
@@ -313,7 +242,7 @@ See [Billing](/guides/billing) for full pricing details.
 **Problem:** IPFS gateway returns 404 or timeout
 
 **Solutions:**
-- Verify the content is still pinned (`acc storage list`)
+- Verify the content is still pinned (`af.storage().list()`)
 - Try a different IPFS gateway
 - Wait a few minutes for propagation on new uploads
 - Check if the CID is correct (copy-paste errors are common)
@@ -323,8 +252,8 @@ See [Billing](/guides/billing) for full pricing details.
 **Problem:** Cannot upload new files
 
 **Solutions:**
-- Check current usage: `acc billing usage`
-- Delete unused files: `acc storage delete`
+- Check your credit balance: `acc billing balance`
+- Delete unused files via the SDK: `af.storage().delete({ cid })`
 - Upgrade your plan for more storage
 
 ## Next Steps

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ layout: home
 
 hero:
   name: ""
-  text: Alternate Cloud Documentation <span class="beta-badge">BETA</span>
+  text: Alternate Clouds Documentation <span class="beta-badge">BETA</span>
   tagline: Deploy AI agents, cloud functions and sites to decentralized infrastructure
   actions:
     - theme: brand
@@ -35,7 +35,7 @@ features:
       src: /icons/database.svg
       alt: Storage
     title: Storage Management
-    details: Unified interface for managing decentralized storage across networks
+    details: Manage decentralized storage across IPFS, Filecoin, and Arweave from the SDK
     link: /guides/storage
     linkText: Learn more
   - icon:
@@ -120,15 +120,16 @@ npm install @alternatefutures/sdk
 ::: code-group
 
 ```bash [CLI]
-# Initialize and deploy a site
-acc sites init
-acc sites deploy
+# Log in (opens your browser)
+acc login
 
-# List your sites
-acc sites list
+# Create and deploy a service
+acc services create
+acc services deploy
 
-# Upload files to IPFS
-acc storage add ./my-files
+# List services and view deployments
+acc services list
+acc deployments
 ```
 
 ```typescript [SDK]
@@ -146,9 +147,13 @@ const af = new AlternateFuturesSdk({
 const sites = await af.sites().list();
 console.log('Sites:', sites);
 
-// Upload to IPFS
-const result = await af.ipfs().add('./dist');
-console.log('CID:', result.pin.cid);
+// Upload a build directory to IPFS
+const [result] = await af.ipfs().addFromPath('./dist');
+console.log('CID:', result.cid.toString());
 ```
 
+:::
+
+::: tip What this maps to in code
+CLI commands are registered in [`src/cli.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts). The SDK's `ipfs().add()` / `addFromPath()` methods live in [`src/clients/ipfs.ts`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipfs.ts).
 :::

--- a/docs/sdk/api.md
+++ b/docs/sdk/api.md
@@ -51,7 +51,7 @@ const sites = await af.sites().list();
 const storage = await af.storage().list();
 ```
 
-**Methods:**
+**Methods:** (source: [`AlternateFuturesSdk`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/AlternateFuturesSdk.ts))
 
 | Method | Returns | Description |
 |--------|---------|-------------|
@@ -71,6 +71,10 @@ const storage = await af.storage().list();
 ### Client
 
 Low-level GraphQL client interface for advanced use cases.
+
+::: warning Experimental
+`createClient` is re-exported from the underlying genql client and is not yet a committed part of the SDK's public surface. The `query`/`mutation` shape may change; prefer the typed clients above.
+:::
 
 ```typescript
 import { createClient } from '@alternatefutures/sdk';
@@ -119,7 +123,7 @@ const accessTokenService = new PersonalAccessTokenService({
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
 | `personalAccessToken` | `string` | Yes | Your personal access token |
-| `projectId` | `string` | Yes | Target project ID |
+| `projectId` | `string` | No | Target project ID |
 
 ### StaticAccessTokenService
 
@@ -129,8 +133,7 @@ Browser-side authentication when you already have a JWT token.
 import { StaticAccessTokenService } from '@alternatefutures/sdk';
 
 const accessTokenService = new StaticAccessTokenService({
-  token: 'jwt-token',
-  projectId: 'project-id',
+  accessToken: 'jwt-token',
 });
 ```
 
@@ -138,8 +141,7 @@ const accessTokenService = new StaticAccessTokenService({
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `token` | `string` | Yes | JWT access token |
-| `projectId` | `string` | Yes | Target project ID |
+| `accessToken` | `string` | Yes | JWT / access token |
 
 ### ApplicationAccessTokenService
 
@@ -150,10 +152,11 @@ import { ApplicationAccessTokenService } from '@alternatefutures/sdk';
 
 const accessTokenService = new ApplicationAccessTokenService({
   clientId: 'your-client-id',
+  authAppsServiceUrl: 'https://auth-apps.alternatefutures.ai',
 });
 
-// Trigger user login flow
-await accessTokenService.login();
+// The token is fetched lazily on first use:
+const token = await accessTokenService.getAccessToken();
 ```
 
 **Constructor Options:**
@@ -161,10 +164,13 @@ await accessTokenService.login();
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
 | `clientId` | `string` | Yes | Your application's Client ID |
+| `authAppsServiceUrl` | `string` | Yes* | Auth-apps service URL. *Required unless the `SDK__AUTH_APPS_URL` env var is set; otherwise the constructor throws. Browser only. |
 
 ---
 
 ## Sites & Deployments
+
+> **What this maps to in code:** [`Site` type and the sites client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/sites.ts) — `get({ id })`, `getBySlug({ slug })`, `list`, `create`, `delete`, `createCustomIpfsDeployment`, `getDeployment`.
 
 ### Site
 
@@ -173,7 +179,7 @@ Represents a deployed static site.
 ```typescript
 import type { Site } from '@alternatefutures/sdk';
 
-const site: Site = await af.sites().get({ slug: 'my-site' });
+const site: Site = await af.sites().getBySlug({ slug: 'my-site' });
 console.log(site.name, site.slug);
 ```
 
@@ -197,9 +203,12 @@ Represents a single deployment of a site.
 ```typescript
 import type { Deployment } from '@alternatefutures/sdk';
 
-const deployments: Deployment[] = await af.sites().listDeployments({
-  siteId: 'site_abc123',
-});
+// Site deployments are exposed on the fetched Site object:
+const site = await af.sites().get({ id: 'site_abc123' });
+const deployments: Deployment[] = site.deployments;
+
+// Fetch a single deployment directly:
+// const deployment = await af.sites().getDeployment({ ... });
 ```
 
 **Properties:**
@@ -240,7 +249,7 @@ Custom domain configuration.
 ```typescript
 import type { Domain } from '@alternatefutures/sdk';
 
-const domain: Domain = await af.domains().create({
+const domain: Domain = await af.domains().createCustomDomain({
   siteId: 'site_abc123',
   hostname: 'www.example.com',
 });
@@ -364,13 +373,13 @@ InterPlanetary Naming System record for mutable content addressing.
 ```typescript
 import type { IpnsRecord } from '@alternatefutures/sdk';
 
-const record: IpnsRecord = await af.ipns().create({
+const record: IpnsRecord = await af.ipns().createRecordForSite({
   siteId: 'site_abc123',
 });
 
-// Update the record to point to new content
-await af.ipns().publish({
-  name: record.name,
+// Update the record to point to new content (keyed by record id)
+await af.ipns().publishRecord({
+  id: record.id,
   hash: 'bafybei...',
 });
 ```
@@ -428,6 +437,8 @@ type AFFunctionStatus = "ACTIVE" | "INACTIVE";
 
 ## Billing
 
+> **What this maps to in code:** [`BillingClient`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/billing.ts) — `getCustomer`, `getActiveSubscription`, `listSubscriptions`, `getCurrentUsage`, `listInvoices`.
+
 ### Customer
 
 Billing customer information.
@@ -454,7 +465,7 @@ Active subscription details.
 ```typescript
 import type { Subscription } from '@alternatefutures/sdk';
 
-const subscription: Subscription = await af.billing().getSubscription();
+const subscription: Subscription | null = await af.billing().getActiveSubscription();
 ```
 
 **Properties:**
@@ -660,13 +671,13 @@ Additional properties are inherited from the platform's gateway schema.
 
 ## Error Handling
 
-All SDK methods throw errors that can be caught and handled:
+All SDK methods throw on failure. **Note:** the exact discriminator on thrown errors (`error.code` vs `error.name`) is not yet finalized in the SDK; the example below is illustrative — inspect the caught error in your environment before branching on a specific field.
 
 ```typescript
 import { AlternateFuturesSdk } from '@alternatefutures/sdk/node';
 
 try {
-  const site = await af.sites().get({ slug: 'nonexistent' });
+  const site = await af.sites().getBySlug({ slug: 'nonexistent' });
 } catch (error) {
   if (error.code === 'NOT_FOUND') {
     console.error('Site not found');
@@ -682,7 +693,7 @@ try {
 
 ## TypeScript Support
 
-Import types directly from the SDK:
+All of these are re-exported from the SDK's [public entry point](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/index.ts). Import types directly from the SDK:
 
 ```typescript
 import {
@@ -721,8 +732,7 @@ let afInstance: AlternateFuturesSdk | null = null;
 export function getAFClient(token: string, projectId: string): AlternateFuturesSdk {
   if (!afInstance) {
     const accessTokenService = new StaticAccessTokenService({
-      token,
-      projectId,
+      accessToken: token,
     });
     afInstance = new AlternateFuturesSdk({ accessTokenService });
   }
@@ -756,8 +766,7 @@ let afInstance: AlternateFuturesSdk | null = null;
 
 function createClient(token: string, projectId: string): AlternateFuturesSdk {
   const accessTokenService = new StaticAccessTokenService({
-    token,
-    projectId,
+    accessToken: token,
   });
   return new AlternateFuturesSdk({ accessTokenService });
 }
@@ -1215,9 +1224,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setState(prev => ({ ...prev, isLoading: true, error: null }));
 
     try {
-      await accessTokenService.login();
-
-      // After successful login, the token is available
+      // The token is fetched lazily; there is no separate login() call.
       const token = await accessTokenService.getAccessToken();
 
       if (token) {
@@ -1350,7 +1357,7 @@ function createAuthStore() {
       update(state => ({ ...state, isLoading: true, error: null }));
 
       try {
-        await accessTokenService.login();
+        // The token is fetched lazily; there is no separate login() call.
         const token = await accessTokenService.getAccessToken();
 
         if (token && browser) {

--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -4,14 +4,14 @@ description: The Alternate Futures JavaScript/TypeScript SDK for programmatic ac
 
 # SDK Documentation
 
-The Alternate Futures SDK provides a JavaScript/TypeScript library for programmatic access to the platform. Build decentralized applications with IPFS storage, serverless functions, and more.
+The Alternate Futures SDK is the JavaScript/TypeScript client for Alternate Clouds. Use it to manage sites, storage, domains, IPNS, ENS, and cloud functions programmatically — from a Node.js backend, a CI pipeline, or the browser.
 
 ## Features
 
 - **Type-Safe** - Full TypeScript support with comprehensive type definitions
 - **Multi-Platform** - Works in both Node.js and browser environments
 - **Complete API Access** - Sites, storage, domains, IPNS, ENS, functions, and billing
-- **Multiple Auth Methods** - Personal access tokens, static tokens, and OAuth flows
+- **Multiple Auth Methods** - Personal access tokens (server-side), static tokens (browser), and an application access-token service for user-facing apps
 
 ## Installation
 
@@ -52,9 +52,9 @@ const af = new AlternateFuturesSdk({
 const sites = await af.sites().list();
 console.log('Sites:', sites);
 
-// Upload to IPFS
-const result = await af.ipfs().add('./dist');
-console.log('CID:', result.pin.cid);
+// Upload a directory to IPFS
+const result = await af.ipfs().addFromPath('./dist');
+console.log('CID:', result.cid.toString());
 ```
 
 ### Browser
@@ -63,8 +63,7 @@ console.log('CID:', result.pin.cid);
 import { AlternateFuturesSdk, StaticAccessTokenService } from '@alternatefutures/sdk';
 
 const accessTokenService = new StaticAccessTokenService({
-  token: 'your-access-token',
-  projectId: 'your-project-id',
+  accessToken: 'your-access-token',
 });
 
 const af = new AlternateFuturesSdk({
@@ -78,6 +77,8 @@ const sites = await af.sites().list();
 **Note:** The Node.js version (`@alternatefutures/sdk/node`) provides access to filesystem-dependent features like directory uploads. The browser version has a narrower feature set suitable for web applications.
 
 ## SDK Clients
+
+> **What this maps to in code:** every accessor below is defined on [`AlternateFuturesSdk`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/AlternateFuturesSdk.ts) — `sites()`, `storage()`, `ipfs()`, `ipns()`, `ens()`, `functions()`, `projects()`, `applications()`, `privateGateways()`, `user()`, `billing()`, plus `observability()` and `getVersion()`.
 
 | Client | Method | Description |
 |--------|--------|-------------|
@@ -119,8 +120,7 @@ Best for client-side apps where the token is already available.
 import { StaticAccessTokenService } from '@alternatefutures/sdk';
 
 const accessTokenService = new StaticAccessTokenService({
-  token: 'jwt-token',
-  projectId: 'project-id',
+  accessToken: 'jwt-token',
 });
 ```
 
@@ -133,27 +133,31 @@ import { ApplicationAccessTokenService } from '@alternatefutures/sdk';
 
 const accessTokenService = new ApplicationAccessTokenService({
   clientId: 'your-client-id',
+  // Browser only. Also requires the SDK__AUTH_APPS_URL env var
+  // (or pass authAppsServiceUrl here).
 });
 
-// Trigger user login
-await accessTokenService.login();
+// No explicit login step — the token is fetched lazily on first use:
+const token = await accessTokenService.getAccessToken();
 ```
 
 ## Common Examples
 
 ### Deploy a Site
 
+> **What this maps to in code:** [`af.ipfs()`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipfs.ts) exposes `add(file)`, `addAll()`, and `addFromPath(path)`, each returning `UploadResult { cid, size, path }`.
+
 ```typescript
 // Create a new site
 const site = await af.sites().create({ name: 'my-site' });
 
-// Upload content to IPFS
-const upload = await af.ipfs().add('./dist');
+// Upload the build output to IPFS
+const upload = await af.ipfs().addFromPath('./dist');
 
-// Create deployment
-const deployment = await af.sites().createDeployment({
+// Deploy the uploaded CID to the site
+const deployment = await af.sites().createCustomIpfsDeployment({
   siteId: site.id,
-  cid: upload.pin.cid,
+  cid: upload.cid,
 });
 ```
 
@@ -172,31 +176,35 @@ await af.storage().delete({ cid: 'bafybei...' });
 
 ### Work with IPNS
 
-```typescript
-// Create IPNS record
-const ipns = await af.ipns().create({ siteId: 'site_abc123' });
+> **What this maps to in code:** [`af.ipns()`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipns.ts) — `createRecord`, `createRecordForSite`, `publishRecord`, `listRecords`, `getRecord`, `deleteRecord`.
 
-// Publish new content
-await af.ipns().publish({
-  name: ipns.name,
+```typescript
+// Create an IPNS record for a site
+const ipns = await af.ipns().createRecordForSite({ siteId: 'site_abc123' });
+
+// Publish new content (keyed by record id, not name)
+await af.ipns().publishRecord({
+  id: ipns.id,
   hash: 'bafybei...',
 });
 
 // List all IPNS records
-const records = await af.ipns().list();
+const records = await af.ipns().listRecords();
 ```
 
 ### Custom Domains
 
+> **What this maps to in code:** [`af.domains()`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/domains.ts) — `createCustomDomain`, `verifyCustomDomain`, `listDomainsForSite`.
+
 ```typescript
-// Add a domain to a site
-const domain = await af.domains().create({
+// Add a custom domain to a site
+const domain = await af.domains().createCustomDomain({
   siteId: 'site_abc123',
   hostname: 'www.example.com',
 });
 
 // Verify DNS configuration
-const verified = await af.domains().verify({ id: domain.id });
+const verified = await af.domains().verifyCustomDomain({ domainId: domain.id });
 ```
 
 ## TypeScript Support

--- a/docs/sdk/installation.md
+++ b/docs/sdk/installation.md
@@ -76,6 +76,8 @@ The SDK supports multiple authentication approaches. Choose the one that fits yo
 
 Best for: Server-side applications, scripts, CI/CD pipelines.
 
+> **What this maps to in code:** [`PersonalAccessTokenService`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/libs/AccessTokenService/PersonalAccessTokenService.ts) — `personalAccessToken` is required; `projectId` is optional.
+
 ```typescript
 import { AlternateFuturesSdk, PersonalAccessTokenService } from '@alternatefutures/sdk/node';
 
@@ -93,7 +95,7 @@ const af = new AlternateFuturesSdk({
 1. Log in to [app.alternatefutures.ai](https://app.alternatefutures.ai)
 2. Go to Settings > API Keys
 3. Create a new Personal Access Token
-4. Copy the token (starts with `pat_`)
+4. Copy the generated token and store it securely
 
 ### 2. Static Access Token (Browser Apps)
 
@@ -103,8 +105,7 @@ Best for: Client-side applications where the token is already available.
 import { AlternateFuturesSdk, StaticAccessTokenService } from '@alternatefutures/sdk';
 
 const accessTokenService = new StaticAccessTokenService({
-  token: 'your-jwt-token',
-  projectId: 'your-project-id',
+  accessToken: 'your-jwt-token',
 });
 
 const af = new AlternateFuturesSdk({
@@ -116,19 +117,23 @@ const af = new AlternateFuturesSdk({
 
 Best for: Building applications that authenticate users via Alternate Futures.
 
+> **What this maps to in code:** [`ApplicationAccessTokenService`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/libs/AccessTokenService/ApplicationAccessTokenService.ts). Browser only — it reads `window.location.origin` and requires an auth-apps URL (via `authAppsServiceUrl` or the `SDK__AUTH_APPS_URL` env var), or the constructor throws.
+
 ```typescript
 import { AlternateFuturesSdk, ApplicationAccessTokenService } from '@alternatefutures/sdk';
 
 const accessTokenService = new ApplicationAccessTokenService({
   clientId: 'your-client-id',
+  authAppsServiceUrl: 'https://auth-apps.alternatefutures.ai',
+  // Or set the SDK__AUTH_APPS_URL env var instead of passing this option.
 });
 
 const af = new AlternateFuturesSdk({
   accessTokenService,
 });
 
-// User login flow
-await accessTokenService.login();
+// No explicit login call — the token is fetched lazily on first use:
+const token = await accessTokenService.getAccessToken();
 ```
 
 ## Environment Configuration
@@ -139,8 +144,8 @@ Store your credentials securely using environment variables:
 
 ```bash
 # .env
-AF_TOKEN=pat_your_personal_access_token_here
-AF_PROJECT_ID=prj_your_project_id_here
+AF_TOKEN=your_personal_access_token_here
+AF_PROJECT_ID=your_project_id_here
 ```
 
 **Important:** Add `.env` to your `.gitignore` to avoid committing secrets.
@@ -252,9 +257,9 @@ async function main() {
   const sites: Site[] = await af.sites().list();
   console.log('Sites:', sites.map(s => s.name));
 
-  // Upload a file to IPFS
-  const uploadResult = await af.ipfs().add('./dist');
-  console.log('Uploaded CID:', uploadResult.pin.cid);
+  // Upload a directory to IPFS
+  const uploadResult = await af.ipfs().addFromPath('./dist');
+  console.log('Uploaded CID:', uploadResult.cid.toString());
 
   // List storage
   const pins: StoragePin[] = await af.storage().list();
@@ -270,6 +275,8 @@ main().catch(console.error);
 
 ## Custom Configuration
 
+> **What this maps to in code:** the full option list lives in [`AlternateFuturesSdk`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/AlternateFuturesSdk.ts) as `AlternateFuturesSdkOptions`.
+
 ### Custom API Endpoints
 
 For self-hosted or development environments:
@@ -280,6 +287,8 @@ const af = new AlternateFuturesSdk({
   graphqlServiceApiUrl: 'https://custom-api.example.com/graphql',
   ipfsStorageApiUrl: 'https://custom-ipfs.example.com',
   uploadProxyApiUrl: 'https://custom-uploads.example.com',
+  // Required to use af.billing() — otherwise billing() throws EnvNotSetError.
+  authServiceUrl: 'https://custom-auth.example.com',
 });
 ```
 

--- a/docs/sdk/quickstart.md
+++ b/docs/sdk/quickstart.md
@@ -49,13 +49,14 @@ console.log('Sites:', sites);
 
 ### Browser
 
+> **What this maps to in code:** [`StaticAccessTokenService`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/libs/AccessTokenService/StaticAccessTokenService.ts) takes a single `accessToken` option.
+
 ```typescript
 import { AlternateFuturesSdk, StaticAccessTokenService } from '@alternatefutures/sdk';
 
 // For browser apps, use StaticAccessTokenService
 const accessTokenService = new StaticAccessTokenService({
-  token: 'your-access-token',
-  projectId: 'your-project-id',
+  accessToken: 'your-access-token',
 });
 
 const af = new AlternateFuturesSdk({
@@ -77,13 +78,15 @@ for (const site of sites) {
 
 ### Upload to IPFS
 
+> **What this maps to in code:** [`af.ipfs().add`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipfs.ts) takes an `IpfsFile` object `{ content, path? }`; use `addFromPath(path)` to upload from the filesystem.
+
 ```typescript
-// Node.js only - upload a file
-const result = await af.ipfs().add('./my-file.txt');
-console.log('CID:', result.pin.cid);
+// Node.js only - upload a file from a path
+const result = await af.ipfs().addFromPath('./my-file.txt');
+console.log('CID:', result.cid.toString());
 
 // Or upload content directly
-const result = await af.ipfs().addFromContent({
+const contentResult = await af.ipfs().add({
   content: 'Hello, decentralized web!',
   path: 'hello.txt',
 });
@@ -106,10 +109,10 @@ await af.storage().delete({ cid: 'bafybei...' });
 
 ```typescript
 // List domains for a site
-const domains = await af.domains().listBySite({ siteId: 'site_abc123' });
+const domains = await af.domains().listDomainsForSite({ siteId: 'site_abc123' });
 
 // Add a custom domain
-const domain = await af.domains().create({
+const domain = await af.domains().createCustomDomain({
   siteId: 'site_abc123',
   hostname: 'www.example.com',
 });
@@ -117,19 +120,25 @@ const domain = await af.domains().create({
 
 ### Create IPNS Records
 
+> **What this maps to in code:** [`af.ipns()`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipns.ts) — `createRecordForSite`, `publishRecord`, `listRecords`.
+
 ```typescript
 // Create an IPNS record for a site
-const ipns = await af.ipns().create({ siteId: 'site_abc123' });
+const ipns = await af.ipns().createRecordForSite({ siteId: 'site_abc123' });
 console.log('IPNS Name:', ipns.name);
 
-// Publish new content to IPNS
-await af.ipns().publish({
-  name: ipns.name,
+// Publish new content to IPNS (keyed by record id)
+await af.ipns().publishRecord({
+  id: ipns.id,
   hash: 'bafybei...',
 });
 ```
 
 ## Error Handling
+
+::: warning
+The exact shape of thrown errors (whether to branch on `error.name` or `error.code`) is not yet finalized in the SDK. Treat the example below as illustrative and inspect the caught error in your environment before depending on a specific field. See the [API Reference](./api#error-handling) for the current contract.
+:::
 
 ```typescript
 import { AlternateFuturesSdk, PersonalAccessTokenService } from '@alternatefutures/sdk/node';

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -73,6 +73,9 @@ npm run build
 
 # Check your af.config.json for the correct output directory
 cat af.config.json
+
+# The CLI resolves af.config using the lookup order in
+# src/utils/configuration/getConfiguration.ts
 ```
 
 ### "Deployment timed out"
@@ -83,7 +86,7 @@ The upload took too long, usually due to a large deployment or slow connection.
 
 ```bash
 # Try deploying again (network issues are often temporary)
-acc sites deploy
+acc services deploy
 
 # For large deployments, check your file count and total size
 du -sh ./dist
@@ -253,10 +256,10 @@ The content is not pinned or the IPFS gateway cannot find it.
 
 ```bash
 # Verify the deployment status
-acc sites list
+acc deployments
 
-# Re-pin the content
-acc sites deploy ./dist --network ipfs
+# Re-deploy to re-pin the content
+acc services deploy
 ```
 
 Common causes:
@@ -299,10 +302,10 @@ You have reached the storage limit for your plan.
 
 **Fix:**
 
-- Remove old deployments that are no longer needed: `acc sites delete <site-slug>`
+- Remove services that are no longer needed: `acc services delete <id>`
 - Upgrade your plan for more storage
 - Use Filecoin for large files (cheaper per GB)
-- Check your current usage: `acc billing usage`
+- Check your current credit balance: `acc billing balance`
 
 ## SSL Certificate Problems
 


### PR DESCRIPTION
Closes #29

Coding + marketing swarm pass over the whole docs site (41 files), verified against `cloud-cli`, `package-cloud-sdk`, `service-cloud-api`.

## What changed (visible content — all verified against source)
- Replaced a **fabricated CLI surface** with the real commands: `login/logout, projects, services, deployments, ssh, pat, templates, billing balance, version`.
- Corrected SDK methods/signatures (`addFromPath`, `getBySlug`, `createCustomIpfsDeployment`, …) and the `af.config` `sites[]` schema.
- Reframed feature guides (functions, agents, …) to the real SDK/GraphQL surface; separated shipped behaviour from roadmap.
- Added 37+ verified "What this maps to in code" GitHub source links.
- VitePress `docs:build` passes; no stub pages.

## Unfinished parts kept (commented out)
Per request, unimplemented CLI commands / SDK methods are **not deleted** — they're preserved as hidden HTML-commented `Roadmap (not yet available)` blocks, ready to uncomment when shipped.

## ⚠️ Reviewer note (from a source audit run after this PR was drafted)
Many of the commented "roadmap" features (`sites`, `storage`, `ipfs`, standalone `functions`, deployable `agents`) were **not merely unbuilt — they were deliberately removed/re-architected by Hayk in PR alternatefutures/cloud-cli#64** (mass deletion `36cb299`), moving to a dashboard + `services`/templates model. So the "not yet available" framing on those hidden blocks is likely wrong; they may need relabelling to "moved to dashboard / deprecated" or removal. Holding as draft pending that call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)