### PR TITLE
docs: re-ground CLI docs vs latest v1.0.2 + fix npm package name to @alternatefutures/acc

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,11 +22,11 @@ The Alternate Futures platform enters public beta, providing decentralized cloud
 - **Observability** - Distributed tracing, metrics, and logging for all deployments
 - **Billing** - Usage-based pricing with Stripe integration and credit system
 
-### CLI v0.2 ([`@alternatefutures/cli` package.json](https://github.com/alternatefutures/cloud-cli/blob/main/package.json))
+### CLI v0.2 ([`@alternatefutures/acc` package.json](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/package.json))
 
 **Released: February 2026**
 
-The `@alternatefutures/cli` package is now available on npm. The CLI binary is `acc`.
+The `@alternatefutures/acc` package is now available on npm. The CLI binary is `acc`.
 
 - `acc login` / `acc logout` - Interactive browser-based authentication
 - `acc projects` - Manage projects and organizations
@@ -38,13 +38,13 @@ The `@alternatefutures/cli` package is now available on npm. The CLI binary is `
 - JSON output mode for scripting and CI/CD integration
 - Environment variable support (`AF_TOKEN`, `AF_PROJECT_ID`)
 
-See the full [command registration in `src/cli.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts).
+See the full [command registration in `src/cli.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts).
 
 ```bash
-npm install -g @alternatefutures/cli
+npm install -g @alternatefutures/acc
 ```
 
-### SDK v0.2 ([`@alternatefutures/sdk` package.json](https://github.com/alternatefutures/package-cloud-sdk/blob/main/package.json))
+### SDK v0.2 ([`@alternatefutures/sdk` package.json](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/package.json))
 
 **Released: February 2026**
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -1,5 +1,5 @@
 ---
-description: Complete reference for the Alternate Clouds CLI (acc) — authentication, projects, services, deployments, SSH, personal access tokens, templates, and billing.
+description: Complete reference for the Alternate Clouds CLI (acc) — authentication, whoami, projects, services, deployments, regions, SSH, file copy, encrypted chat, personal access tokens, templates, and billing.
 ---
 
 # CLI Commands
@@ -23,10 +23,14 @@ acc services deploy --help # Help for a single command
 | Command | Description |
 |---------|-------------|
 | [`acc login`](#acc-login) / [`acc logout`](#acc-logout) | Authenticate or end your CLI session |
+| [`acc whoami`](#acc-whoami) | Show your identity and active project (agent pre-flight) |
 | [`acc projects`](#acc-projects) | Create, list, switch, rename, and delete projects |
 | [`acc services`](#acc-services) | Create, deploy, inspect, and manage services |
 | [`acc deployments`](#acc-deployments) | List and filter deployments |
+| [`acc regions`](#acc-regions) | List regions with availability and pricing |
 | [`acc ssh`](#acc-ssh) | Open an interactive shell in a running deployment |
+| [`acc cp`](#acc-cp) | Copy files to/from a deployment |
+| [`acc chat`](#acc-chat) | End-to-end encrypted chat (auth-free) |
 | [`acc pat`](#acc-pat) | Manage personal access tokens |
 | [`acc templates`](#acc-templates) | Browse service templates |
 | [`acc billing`](#acc-billing) | View your credit balance |
@@ -48,7 +52,7 @@ acc login --email      # Email verification code (no browser)
 | `-e, --email` | Log in via email verification instead of a browser |
 | `--auth-url <url>` | Override the auth service URL (e.g. `http://localhost:3001`) |
 
-> **What this maps to in code:** the command is registered in [`cli.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts). Browser login runs [`login.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/auth/login.ts); `--email` runs [`loginEmail.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/auth/loginEmail.ts).
+> **What this maps to in code:** the command is registered in [`cli.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts). Browser login runs [`login.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/auth/login.ts); `--email` runs [`loginEmail.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/auth/loginEmail.ts).
 
 ### `acc logout`
 
@@ -58,7 +62,24 @@ End your CLI session and clear stored credentials.
 acc logout
 ```
 
-> **What this maps to in code:** registered in [`cli.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts), handled by [`logout.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/auth/logout.ts).
+> **What this maps to in code:** registered in [`cli.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts), handled by [`logout.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/auth/logout.ts).
+
+### `acc whoami`
+
+Report the current identity and active project. This is an agent pre-flight check: run it before any mutating command to confirm you are authenticated, as whom, and which project is active. It exits non-zero when there is no session, so wrapping scripts and skills can branch cleanly without triggering a login redirect.
+
+```bash
+acc whoami          # Human-readable
+acc whoami --json   # Machine-readable (for agents/CI)
+```
+
+| Option | Description |
+|--------|-------------|
+| `--json` | Machine-readable JSON output (for agents/CI) |
+
+The `--json` payload reports `authenticated` (boolean), and when signed in, a `user` object (`id`, `email`, `username`, `walletAddress`) and the active `project` (`id`, `name`, `slug`, or `null` when none is selected).
+
+> **What this maps to in code:** the command is registered in [`cli.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts) and handled by [`whoami.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/whoami.ts).
 
 ## Projects
 
@@ -118,7 +139,7 @@ acc projects delete
 acc projects delete prj_abc123
 ```
 
-> **What this maps to in code:** all `projects` subcommands are wired up in [`projects/index.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/projects/index.ts).
+> **What this maps to in code:** all `projects` subcommands are wired up in [`projects/index.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/projects/index.ts).
 
 ## Services
 
@@ -143,11 +164,40 @@ acc services list
 
 #### `acc services create`
 
-Create a new service from a template. Runs interactive prompts to choose the template and configure the service.
+Create a new service — from a template, a Docker image, or an empty server. With no flags it runs interactive prompts; pass flags to create non-interactively. The deploy-side flags below are shared with `acc services deploy`.
 
 ```bash
 acc services create
+acc services create --kind template --template <id> --name my-svc
+acc services create --kind docker --image nginx:latest --port 80
+acc services create --kind server --os ubuntu:24.04 --ssh-key-file ~/.ssh/id_ed25519.pub
 ```
+
+| Option | Description |
+|--------|-------------|
+| `--kind <kind>` | Service kind: `template`, `docker`, `server`, `function`, `github` |
+| `--name <name>` | Service name (skips the name prompt; must be unique in the project) |
+| `--template <id>` | Template id (for `--kind template` — skips the catalog browse) |
+| `--image <ref>` | Docker image (for `--kind docker`, e.g. `nginx:latest`) |
+| `--port <n>` | Container port (for `--kind docker`) |
+| `--os <base>` | Base OS image (for `--kind server`, e.g. `ubuntu:24.04`) |
+| `--confidential` | Deploy on a TEE (Phala) — verifiable confidential compute |
+| `--region <region>` | Curated region: `us-east`, `us-west`, `eu`, `asia` |
+| `--cpu <cores>` | Override CPU (vCPUs) |
+| `--memory <size>` | Override memory (e.g. `4Gi`) |
+| `--storage <size>` | Override storage (e.g. `20Gi`) |
+| `--gpu` / `--no-gpu` | Attach a GPU / skip GPU |
+| `--gpu-model <model>` | GPU model (e.g. `H100`, `H200`, `A100`, `RTX4090`) |
+| `--gpu-count <n>` | Number of GPUs |
+| `--spend <mode>` | Spend control: `payg`, `budget`, `stop` |
+| `--budget-total <usd>` | Budget cap (lifetime, USD) |
+| `--budget-monthly <usd>` | Budget cap (per month, USD) |
+| `--stop-hours <n>` | Auto-stop after N hours |
+| `--stop-days <n>` | Auto-stop after N days |
+| `--env <pair>` | Set required env var as `KEY=VALUE` (repeatable) |
+| `--ssh-key <pubkey>` | Break-glass OpenSSH public key (`--kind server`) |
+| `--ssh-key-file <path>` | Read the break-glass public key from a file |
+| `-y, --yes` | Skip confirmation prompts |
 
 #### `acc services info`
 
@@ -160,12 +210,34 @@ acc services info svc_abc123
 
 #### `acc services deploy`
 
-Deploy (or redeploy) a service.
+Deploy (or redeploy) a service. Pass a service ID or select interactively. Flags let you override compute, region, spend controls, and env for this deploy.
 
 ```bash
 acc services deploy
 acc services deploy svc_abc123
+acc services deploy svc_abc123 --region eu --gpu --gpu-model H100
+acc services deploy svc_abc123 --spend budget --budget-monthly 50 --yes
 ```
+
+| Option | Description |
+|--------|-------------|
+| `--region <region>` | Curated region: `us-east`, `us-west`, `eu`, `asia`. Omit for "Any (cheapest globally)" |
+| `--confidential` | Deploy on a TEE (Phala) — verifiable confidential compute |
+| `--cpu <cores>` | Override CPU (vCPUs) |
+| `--memory <size>` | Override memory (e.g. `4Gi`) |
+| `--storage <size>` | Override storage (e.g. `20Gi`) |
+| `--gpu` / `--no-gpu` | Attach a GPU / skip GPU even if the template defaults to one |
+| `--gpu-model <model>` | GPU model (`H100`, `H200`, `A100`, `RTX4090`, ...) |
+| `--gpu-count <n>` | Number of GPUs |
+| `--spend <mode>` | Spend control: `payg`, `budget`, `stop` |
+| `--budget-total <usd>` | Budget cap (lifetime, USD) |
+| `--budget-monthly <usd>` | Budget cap (per month, USD) |
+| `--stop-hours <n>` | Auto-stop after N hours |
+| `--stop-days <n>` | Auto-stop after N days |
+| `--env <pair>` | Set required env var as `KEY=VALUE` (repeatable) |
+| `--ssh-key <pubkey>` | Break-glass OpenSSH public key (raw server → Spheron; ignored on Akash/Phala) |
+| `--ssh-key-file <path>` | Read the break-glass public key from a file |
+| `-y, --yes` | Skip confirmation prompts |
 
 #### `acc services logs`
 
@@ -198,7 +270,40 @@ acc services delete
 acc services delete svc_abc123
 ```
 
-> **What this maps to in code:** every `services` subcommand — including the `deploy` path — is registered in [`services/index.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/services/index.ts); the deploy handler lives in [`services/deploy.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/services/deploy.ts).
+#### `acc services env`
+
+Manage a service's environment variables.
+
+```bash
+acc services env list                       # List env vars (select service interactively)
+acc services env list my-svc
+acc services env set my-svc DATABASE_URL postgres://...
+acc services env unset my-svc DATABASE_URL
+acc services env unset my-svc DATABASE_URL --yes
+```
+
+| Subcommand | Description |
+|------------|-------------|
+| `env list [service]` | List env vars for a service |
+| `env set <service> <key> <value>` | Set an env var (creates or updates) |
+| `env unset <service> <key>` | Delete an env var (`-y, --yes` skips the confirmation prompt) |
+
+#### `acc services link` / `acc services unlink`
+
+Link two services so the target's connection info is exposed to the source as environment variables. Pass the source and target, or select interactively.
+
+```bash
+acc services link api database --alias DB    # Exposes DB_* env vars on `api`
+acc services unlink api database
+acc services unlink api database --yes
+```
+
+| Option | Description |
+|--------|-------------|
+| `--alias <name>` | Alias used as the env key prefix (e.g. `DB`) — `link` only |
+| `-y, --yes` | Skip confirmation prompt — `unlink` only |
+
+> **What this maps to in code:** every `services` subcommand — including the `deploy` path, `env`, and `link`/`unlink` — is registered in [`services/index.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/services/index.ts); the deploy handler lives in [`services/deploy.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/services/deploy.ts).
 
 ## Deployments
 
@@ -233,7 +338,30 @@ Alias for the above; accepts the same options.
 acc deployments list --status active
 ```
 
-> **What this maps to in code:** the `deployments` group and its filtering logic are in [`deployments/index.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/deployments/index.ts).
+> **What this maps to in code:** the `deployments` group and its filtering logic are in [`deployments/index.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/deployments/index.ts).
+
+## Regions
+
+### `acc regions`
+
+List curated region buckets (`us-east`, `us-west`, `eu`, `asia`) with live provider availability and pricing — verified/online provider counts, recent bids in the last 24h, a confidence signal, and the median USD/hr price. Use it as a "what's available right now" sanity check before deploying with `--region`.
+
+```bash
+acc regions                          # Akash regions (default provider)
+acc regions --provider phala         # Phala (currently single-region)
+acc regions --gpu h100               # Median price for a specific GPU model
+```
+
+| Option | Description |
+|--------|-------------|
+| `--provider <name>` | Filter by provider: `akash` or `phala` (default: `akash`) |
+| `--gpu <model>` | Surface the median price for a specific GPU model (e.g. `h100`, `h200`, `a100`, `rtx4090`) |
+
+::: tip Deploying to a region
+Feed a region id into deploy: `acc services deploy <id> --region <region>`. Omit `--region` for "Any (cheapest globally)", today's default.
+:::
+
+> **What this maps to in code:** the `regions` command is registered in [`regions/index.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/regions/index.ts), with the handler in [`regions/list.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/regions/list.ts).
 
 ## SSH
 
@@ -253,7 +381,27 @@ acc ssh svc_abc123 --service worker      # For multi-service deployments
 | `--service <name>` | SDL service name, for multi-service deployments |
 | `--command <cmd>` | Command to run (default: `/bin/bash`) |
 
-> **What this maps to in code:** registered in [`ssh/index.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/ssh/index.ts).
+> **What this maps to in code:** registered in [`ssh/index.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/ssh/index.ts).
+
+## Copy Files
+
+### `acc cp`
+
+Copy a file to or from a running deployment. Mark the remote side as `<serviceId>:<path>`; the other argument is a local path. The direction is inferred from which argument carries the `<serviceId>:` prefix.
+
+```bash
+acc cp ./local.txt svc_abc123:/app/local.txt        # Upload local → deployment
+acc cp svc_abc123:/app/output.log ./output.log      # Download deployment → local
+acc cp ./data.json svc_abc123:/app/data.json --service worker   # Multi-service deployment
+```
+
+| Argument / Option | Description |
+|-------------------|-------------|
+| `<source>` | Source path — local, or `<serviceId>:<path>` for the remote side |
+| `<dest>` | Destination path — local, or `<serviceId>:<path>` for the remote side |
+| `--service <name>` | SDL service name, for multi-service deployments |
+
+> **What this maps to in code:** the `cp` command is registered in [`cp/index.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/cp/index.ts), with the transfer logic in [`cp/transfer.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/cp/transfer.ts).
 
 ## Personal Access Tokens
 
@@ -288,7 +436,7 @@ Delete a personal access token by ID.
 acc pat delete <personalAccessTokenId>
 ```
 
-> **What this maps to in code:** the `pat` group is defined in [`pat/index.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/pat/index.ts).
+> **What this maps to in code:** the `pat` group is defined in [`pat/index.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/pat/index.ts).
 
 ## Templates
 
@@ -315,7 +463,7 @@ Show detailed information for a template.
 acc templates info <templateId>
 ```
 
-> **What this maps to in code:** the `templates` group is defined in [`templates/index.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/templates/index.ts).
+> **What this maps to in code:** the `templates` group is defined in [`templates/index.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/templates/index.ts).
 
 ## Billing
 
@@ -331,7 +479,95 @@ acc billing balance
 `acc billing` currently implements a single subcommand: `balance`. Additional billing commands are planned but not yet shipped.
 :::
 
-> **What this maps to in code:** the `billing` group is registered in [`billing/index.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/billing/index.ts), with the handler in [`billing/balance.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/billing/balance.ts).
+> **What this maps to in code:** the `billing` group is registered in [`billing/index.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/billing/index.ts), with the handler in [`billing/balance.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/billing/balance.ts).
+
+## Chat
+
+End-to-end encrypted chat. This client is auth-free — it talks directly to alt-chat relays and does not require `acc login`. The **room passphrase is the only thing that selects a room** (there is no room name): everyone who shares the passphrase is in the same room. Running `acc chat` with no subcommand prints help; `acc chat <target>` defaults to `join`.
+
+::: warning Prefer env vars for secrets
+Pass the passphrase via `AF_CHAT_PASSWORD` rather than `--password` — an argv passphrase is visible in `ps` and your shell history. `AF_CHAT_USERNAME` and `AF_CHAT_IDENTITY` have the same env-var equivalents.
+:::
+
+**Session options** (accepted by every `chat` subcommand):
+
+| Option | Description |
+|--------|-------------|
+| `--password <passphrase>` | Room passphrase — the only thing that selects the room. Prefer `AF_CHAT_PASSWORD` |
+| `--username <name>` | Display name (or `AF_CHAT_USERNAME`; defaults to your OS user) |
+| `--identity <file>` | Ed25519 identity file (or `AF_CHAT_IDENTITY`). Distinct files = distinct identities — give each agent its own |
+| `-p, --project <id>` | Project to resolve a bare service name against (needs `acc login`) |
+
+The optional `[target]` is a service name/slug, full URL, or host. Omit it to use `AF_CHAT_URL` or the public demo relay (`chat.alternatefutures.ai`).
+
+### `acc chat join`
+
+Open an interactive encrypted chat session (TUI). This is the default: `acc chat <target>` runs `join`.
+
+```bash
+acc chat join
+acc chat my-relay --username alice
+```
+
+### `acc chat send`
+
+Send one message to a room, then exit — no TTY required, so it fits agents and CI. The message can be passed with `--message` or piped on stdin.
+
+```bash
+acc chat send --message "deploy finished"
+echo "deploy finished" | acc chat send
+acc chat send --message "on it" --reply-to <pubkey>:<seq> --json
+```
+
+| Option | Description |
+|--------|-------------|
+| `--message <text>` | Message text (or pipe it on stdin) |
+| `--reply-to <pubkey:seq>` | Thread this as a reply (copy the `<pubkey>:<seq>` from `acc chat read --json`) |
+| `--json` | Machine-readable JSON output (for agents/CI) |
+
+### `acc chat read`
+
+Print room history and exit; add `--watch` to stay connected and stream new messages and presence.
+
+```bash
+acc chat read
+acc chat read --json
+acc chat read --watch --json    # NDJSON, one event per line
+```
+
+| Option | Description |
+|--------|-------------|
+| `--watch` | Stay connected and stream new messages + presence |
+| `--json` | JSON snapshot; with `--watch`, NDJSON one event per line |
+
+### `acc chat agent`
+
+Participate as an agent. Three modes: **driver** (prints the next addressed message as JSON, then exits — one turn), **bridge** (`--bridge`, a persistent presence that relays via inbox/outbox files — best for a live LLM agent), and **bot** (`--exec`, a self-contained headless bot).
+
+```bash
+# Driver mode — leaves each turn
+acc chat agent my-relay --username Claude --mention claude
+
+# Bridge mode — persistent presence, relays via files
+acc chat agent my-relay --username Claude --mention claude --bridge
+
+# Bot mode — external brain
+acc chat agent --mention bot --exec 'echo "pong: $AF_MSG_TEXT"'
+```
+
+| Option | Description |
+|--------|-------------|
+| `--bridge` | Persistent presence; addressed messages → inbox, lines appended to outbox → sent |
+| `--inbox <file>` | Bridge inbox file (default `~/.af-chat/<room>.in.jsonl`) |
+| `--outbox <file>` | Bridge outbox file (default `~/.af-chat/<room>.out`) |
+| `--exec <command>` | Bot mode: a command that reads the message (stdin JSON + `AF_MSG_*` env) and prints the reply |
+| `--mention <words>` | Comma-separated trigger words; reply only when a message contains one (default: your display name) |
+| `--all` | Reply to every message, not just when mentioned |
+| `--context <n>` | Recent messages of context passed to the brain (default `10`) |
+| `--timeout <ms>` | Max time for the brain to produce a reply (default `60000`) |
+| `--cooldown <ms>` | Minimum gap between replies — throttles runaway loops (default `0`) |
+
+> **What this maps to in code:** the `chat` group and all its subcommands are registered in [`chat/index.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/chat/index.ts).
 
 ## Version
 
@@ -344,7 +580,7 @@ acc version
 acc --version
 ```
 
-> **What this maps to in code:** the `version` command and `--version` flag are wired up in [`cli.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts).
+> **What this maps to in code:** the `version` command and `--version` flag are wired up in [`cli.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts).
 
 <!-- ROADMAP — not yet shipped. Uncomment each section as the feature ships.
 

--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -30,10 +30,10 @@ acc services deploy --help # Help for a single command
 | [`acc regions`](#acc-regions) | List regions with availability and pricing |
 | [`acc ssh`](#acc-ssh) | Open an interactive shell in a running deployment |
 | [`acc cp`](#acc-cp) | Copy files to/from a deployment |
-| [`acc chat`](#acc-chat) | End-to-end encrypted chat (auth-free) |
-| [`acc pat`](#acc-pat) | Manage personal access tokens |
-| [`acc templates`](#acc-templates) | Browse service templates |
-| [`acc billing`](#acc-billing) | View your credit balance |
+| [`acc chat`](#chat) | End-to-end encrypted chat (auth-free) |
+| [`acc pat`](#personal-access-tokens) | Manage personal access tokens |
+| [`acc templates`](#templates) | Browse service templates |
+| [`acc billing`](#billing) | View your credit balance |
 | [`acc version`](#acc-version) | Print the installed CLI version |
 
 ## Authentication

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -22,15 +22,15 @@ Install the CLI globally using your preferred package manager:
 ::: code-group
 
 ```bash [npm]
-npm install -g @alternatefutures/cli
+npm install -g @alternatefutures/acc
 ```
 
 ```bash [pnpm]
-pnpm add -g @alternatefutures/cli
+pnpm add -g @alternatefutures/acc
 ```
 
 ```bash [yarn]
-yarn global add @alternatefutures/cli
+yarn global add @alternatefutures/acc
 ```
 
 :::
@@ -65,13 +65,20 @@ acc deployments list
 | Command | Description |
 |---------|-------------|
 | `acc login` / `acc logout` | Authenticate or end your CLI session |
+| `acc whoami` | Show your identity and active project — [whoami.ts](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/whoami.ts) |
 | `acc projects` | Create, list, switch, rename, and delete projects |
 | `acc services` | Create, deploy, inspect, and manage services |
 | `acc deployments` | List and filter deployments |
+| `acc regions` | List regions with availability and pricing — [regions/index.ts](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/regions/index.ts) |
+| `acc templates` | Browse and inspect deployable templates |
 | `acc ssh` | Open a shell into a running service |
+| `acc cp` | Copy a file to/from a deployment (`<serviceId>:<path>`) — [cp/index.ts](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/cp/index.ts) |
+| `acc chat` | End-to-end encrypted chat with services and agents — [chat/index.ts](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/chat/index.ts) |
 | `acc billing` | View your credit balance |
+| `acc pat` | Create and manage personal access tokens |
+| `acc version` | Print the CLI version |
 
-> **What this maps to in code:** command registration lives in [command registration (cli.ts)](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts). `templates` and `pat` are also registered but hidden from top-level help.
+> **What this maps to in code:** command registration lives in [command registration (cli.ts)](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts). All groups above are surfaced in top-level help; `version` is a hidden alias for `acc --version`.
 
 ## Getting Help
 
@@ -103,7 +110,7 @@ export AF_PROJECT_ID="your-project-id"
 | `AF_PROJECT_ID` | Default project ID for commands |
 | `AF_ORG_ID` | Default organization ID |
 
-> **What this maps to in code:** these are the only variables the CLI reads — see [CLI environment variables (secrets.ts)](https://github.com/alternatefutures/cloud-cli/blob/main/src/secrets.ts).
+> **What this maps to in code:** these are the only variables the CLI reads — see [CLI environment variables (secrets.ts)](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/secrets.ts).
 
 ## Configuration File
 
@@ -123,7 +130,7 @@ The CLI reads deployment configuration from an `af.config` file in your project 
 
 Create the file manually in your project root.
 
-> **What this maps to in code:** the schema (`AlternateFuturesRootConfig` with a `sites[]` array and an optional `functions[]` block) is defined in [af.config type definition](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts).
+> **What this maps to in code:** the schema (`AlternateFuturesRootConfig` with a `sites[]` array and an optional `functions[]` block) is defined in [af.config type definition](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/utils/configuration/types.ts).
 
 ## Documentation
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -110,7 +110,7 @@ export AF_PROJECT_ID="your-project-id"
 | `AF_PROJECT_ID` | Default project ID for commands |
 | `AF_ORG_ID` | Default organization ID |
 
-> **What this maps to in code:** these are the only variables the CLI reads — see [CLI environment variables (secrets.ts)](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/secrets.ts).
+> **What this maps to in code:** these are the core auth/config variables, read via [secrets.ts](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/secrets.ts). The `chat` commands additionally read `AF_CHAT_PASSWORD`, `AF_CHAT_USERNAME`, `AF_CHAT_IDENTITY`, and `AF_CHAT_URL` — see [Chat](/cli/commands#chat).
 
 ## Configuration File
 

--- a/docs/cli/installation.md
+++ b/docs/cli/installation.md
@@ -1,10 +1,10 @@
 ---
-description: Install and configure the Alternate Futures CLI on macOS, Linux, or Windows with npm, pnpm, or yarn.
+description: Install and configure the Alternate Clouds CLI (acc) on macOS, Linux, or Windows with npm, pnpm, or yarn.
 ---
 
 # CLI Installation
 
-Complete guide to installing and configuring the Alternate Futures CLI.
+Complete guide to installing and configuring the Alternate Clouds CLI (`acc`).
 
 ## Requirements
 
@@ -17,7 +17,7 @@ Check your Node.js version:
 node --version  # Should be v18.18.2 or higher
 ```
 
-> **What this maps to in code:** the engine range and package name are declared in [package.json engines / bin](https://github.com/alternatefutures/cloud-cli/blob/main/package.json).
+> **What this maps to in code:** the engine range and package name are declared in [package.json engines / bin](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/package.json).
 
 ## Installation
 
@@ -26,15 +26,15 @@ Install the CLI globally using your preferred package manager:
 ::: code-group
 
 ```bash [npm]
-npm install -g @alternatefutures/cli
+npm install -g @alternatefutures/acc
 ```
 
 ```bash [pnpm]
-pnpm add -g @alternatefutures/cli
+pnpm add -g @alternatefutures/acc
 ```
 
 ```bash [yarn]
-yarn global add @alternatefutures/cli
+yarn global add @alternatefutures/acc
 ```
 
 :::
@@ -51,7 +51,7 @@ You should see the version number displayed. If you see "command not found", try
 
 1. Restart your terminal
 2. Check that npm's global bin directory is in your PATH
-3. Run `npm list -g @alternatefutures/cli` to confirm installation
+3. Run `npm list -g @alternatefutures/acc` to confirm installation
 
 ## Authentication
 
@@ -120,7 +120,7 @@ Create a config file in your project root. The CLI accepts `af.config.ts`, `af.c
 }
 ```
 
-> **What this maps to in code:** the schema (a top-level `sites[]` array, plus an optional `functions[]` block) is defined in [af.config type definition](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts).
+> **What this maps to in code:** the schema (a top-level `sites[]` array, plus an optional `functions[]` block) is defined in [af.config type definition](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/utils/configuration/types.ts).
 
 <!-- Removed / re-architected commands (kept for reference)
 
@@ -158,7 +158,7 @@ This creates `af.config.json`:
 | `AF_PROJECT_ID` | Default project ID | `prj_abc123` |
 | `AF_ORG_ID` | Default organization ID | `org_abc123` |
 
-> **What this maps to in code:** these are the only variables the CLI reads — see [env vars read by the CLI](https://github.com/alternatefutures/cloud-cli/blob/main/src/secrets.ts).
+> **What this maps to in code:** these are the only variables the CLI reads — see [env vars read by the CLI](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/secrets.ts).
 
 ### Setting Environment Variables
 
@@ -217,7 +217,7 @@ jobs:
         run: npm run build
 
       - name: Install AF CLI
-        run: npm install -g @alternatefutures/cli
+        run: npm install -g @alternatefutures/acc
 
       - name: Deploy
         run: acc services deploy <service-id>
@@ -248,7 +248,7 @@ deploy:
   script:
     - npm ci
     - npm run build
-    - npm install -g @alternatefutures/cli
+    - npm install -g @alternatefutures/acc
     - acc services deploy <service-id>
   variables:
     AF_TOKEN: $AF_TOKEN
@@ -264,15 +264,15 @@ Keep your CLI up to date:
 ::: code-group
 
 ```bash [npm]
-npm update -g @alternatefutures/cli
+npm update -g @alternatefutures/acc
 ```
 
 ```bash [pnpm]
-pnpm update -g @alternatefutures/cli
+pnpm update -g @alternatefutures/acc
 ```
 
 ```bash [yarn]
-yarn global upgrade @alternatefutures/cli
+yarn global upgrade @alternatefutures/acc
 ```
 
 :::
@@ -283,8 +283,8 @@ yarn global upgrade @alternatefutures/cli
 
 - Ensure the global npm directory is in your PATH
 - Try restarting your terminal
-- Run `npm list -g @alternatefutures/cli` to confirm installation
-- Try reinstalling: `npm uninstall -g @alternatefutures/cli && npm install -g @alternatefutures/cli`
+- Run `npm list -g @alternatefutures/acc` to confirm installation
+- Try reinstalling: `npm uninstall -g @alternatefutures/acc && npm install -g @alternatefutures/acc`
 
 ### "Login failed" or browser doesn't open
 
@@ -304,12 +304,12 @@ Try installing with elevated permissions or use a Node version manager:
 
 ```bash
 # Using sudo (not recommended)
-sudo npm install -g @alternatefutures/cli
+sudo npm install -g @alternatefutures/acc
 
 # Better: Use nvm to manage Node
 nvm install 20
 nvm use 20
-npm install -g @alternatefutures/cli
+npm install -g @alternatefutures/acc
 ```
 
 ## Uninstalling
@@ -319,15 +319,15 @@ To remove the CLI:
 ::: code-group
 
 ```bash [npm]
-npm uninstall -g @alternatefutures/cli
+npm uninstall -g @alternatefutures/acc
 ```
 
 ```bash [pnpm]
-pnpm remove -g @alternatefutures/cli
+pnpm remove -g @alternatefutures/acc
 ```
 
 ```bash [yarn]
-yarn global remove @alternatefutures/cli
+yarn global remove @alternatefutures/acc
 ```
 
 :::

--- a/docs/cli/installation.md
+++ b/docs/cli/installation.md
@@ -158,7 +158,7 @@ This creates `af.config.json`:
 | `AF_PROJECT_ID` | Default project ID | `prj_abc123` |
 | `AF_ORG_ID` | Default organization ID | `org_abc123` |
 
-> **What this maps to in code:** these are the only variables the CLI reads — see [env vars read by the CLI](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/secrets.ts).
+> **What this maps to in code:** these are the core auth/config variables, read via [secrets.ts](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/secrets.ts). The `chat` commands additionally read `AF_CHAT_*` (password/username/identity/url) — see the [Chat commands](/cli/commands#chat).
 
 ### Setting Environment Variables
 

--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -9,7 +9,7 @@ Alternate Clouds agents are **chat agents**: a named agent with a system prompt,
 :::
 
 ::: tip What this maps to in code
-The [Agent GraphQL type and mutations](https://github.com/alternatefutures/service-cloud-api/blob/main/src/schema/typeDefs.ts) define the real surface: `Agent { id name slug description avatar systemPrompt model status }`, `CreateAgentInput { name, slug, description, systemPrompt, model, functionId }`, and the mutations `createAgent`, `createChat`, `sendMessage`, `deleteChat`.
+The [Agent GraphQL type and mutations](https://github.com/alternatefutures/alternate-clouds-api/blob/main/src/schema/typeDefs.ts) define the real surface: `Agent { id name slug description avatar systemPrompt model status }`, `CreateAgentInput { name, slug, description, systemPrompt, model, functionId }`, and the mutations `createAgent`, `createChat`, `sendMessage`, `deleteChat`.
 :::
 
 ## What a chat agent is

--- a/docs/guides/api-keys.md
+++ b/docs/guides/api-keys.md
@@ -101,7 +101,7 @@ acc pat delete <token-id>
 ```
 
 ::: tip What this maps to in code
-See the [pat CLI command](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/pat/index.ts). `create` takes only `--name`; there are no `--expires` or `--permissions` flags yet.
+See the [pat CLI command](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/pat/index.ts). `create` takes only `--name`; there are no `--expires` or `--permissions` flags yet.
 :::
 
 ## Managing API Keys
@@ -216,7 +216,7 @@ If you have 500 active keys:
 **Tips to manage your keys:**
 - Delete unused or expired keys to stay organized
 - Use expiration dates for temporary access
-- Monitor your limits via the [`apiKeyRateLimit` query](https://github.com/alternatefutures/service-cloud-api/blob/main/src/schema/typeDefs.ts):
+- Monitor your limits via the [`apiKeyRateLimit` query](https://github.com/alternatefutures/alternate-clouds-api/blob/main/src/schema/typeDefs.ts):
   ```graphql
   query {
     apiKeyRateLimit {

--- a/docs/guides/applications.md
+++ b/docs/guides/applications.md
@@ -15,8 +15,8 @@ Applications are OAuth 2.0 applications that can authenticate users and access t
 - **Whitelist Domains** - Allowed domains for CORS and OAuth redirects
 
 ::: info What this maps to in code
-- **SDK:** [applications client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/applications.ts) — `create({ name, whitelistDomains }) → clientId`, `list`, `update`, `delete`.
-- **API:** [`Application` GraphQL type](https://github.com/alternatefutures/service-cloud-api/blob/main/src/schema/typeDefs.ts) — `clientId`, `whitelistDomains`.
+- **SDK:** [applications client](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/applications.ts) — `create({ name, whitelistDomains }) → clientId`, `list`, `update`, `delete`.
+- **API:** [`Application` GraphQL type](https://github.com/alternatefutures/alternate-clouds-api/blob/main/src/schema/typeDefs.ts) — `clientId`, `whitelistDomains`.
 :::
 
 ::: tip CLI

--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -286,7 +286,7 @@ my-project/
 └── deploy.sh         # Deployment script
 ```
 
-The CLI resolves configuration in order `af.config.ts` > `af.config.js` > `af.config.json` — see [getConfiguration.ts](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/getConfiguration.ts).
+The CLI resolves configuration in order `af.config.ts` > `af.config.js` > `af.config.json` — see [getConfiguration.ts](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/utils/configuration/getConfiguration.ts).
 
 ## Next Steps
 

--- a/docs/guides/billing.md
+++ b/docs/guides/billing.md
@@ -29,7 +29,7 @@ acc billing balance
 ```
 
 ::: tip What this maps to in code
-`balance` is the only subcommand defined in the [billing CLI command](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/billing/index.ts). Customer, invoice, subscription, usage, and payment-method operations are available through the SDK's [billing client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/billing.ts) (`af.billing().getCustomer()`, `listInvoices()`, `listSubscriptions()`, `getCurrentUsage()`, `listPaymentMethods()`) — CLI coverage is on the roadmap.
+`balance` is the only subcommand defined in the [billing CLI command](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/billing/index.ts). Customer, invoice, subscription, usage, and payment-method operations are available through the SDK's [billing client](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/billing.ts) (`af.billing().getCustomer()`, `listInvoices()`, `listSubscriptions()`, `getCurrentUsage()`, `listPaymentMethods()`) — CLI coverage is on the roadmap.
 :::
 
 ### Invoices, subscriptions, usage, and payment methods (SDK)

--- a/docs/guides/cicd.md
+++ b/docs/guides/cicd.md
@@ -37,7 +37,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to Alternate Clouds
-        run: npx @alternatefutures/cli services deploy
+        run: npx @alternatefutures/acc services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN }}
           AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID }}
@@ -80,14 +80,14 @@ jobs:
 
       - name: Deploy to Staging
         if: github.ref == 'refs/heads/staging'
-        run: npx @alternatefutures/cli services deploy
+        run: npx @alternatefutures/acc services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN_STAGING }}
           AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID_STAGING }}
 
       - name: Deploy to Production
         if: github.ref == 'refs/heads/main'
-        run: npx @alternatefutures/cli services deploy
+        run: npx @alternatefutures/acc services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN_PROD }}
           AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID_PROD }}
@@ -123,7 +123,7 @@ deploy:
   only:
     - main
   script:
-    - npm install -g @alternatefutures/cli
+    - npm install -g @alternatefutures/acc
     - acc services deploy
   variables:
     AF_TOKEN: $AF_TOKEN
@@ -167,7 +167,7 @@ jobs:
       - run:
           name: Deploy
           command: |
-            npm install -g @alternatefutures/cli
+            npm install -g @alternatefutures/acc
             acc services deploy
 
 workflows:
@@ -201,7 +201,7 @@ Then add deployment hook:
 {
   "scripts": {
     "vercel-build": "npm run build && npm run deploy:af",
-    "deploy:af": "npx @alternatefutures/cli services deploy"
+    "deploy:af": "npx @alternatefutures/acc services deploy"
   }
 }
 ```
@@ -238,7 +238,7 @@ pipeline {
                 branch 'main'
             }
             steps {
-                sh 'npm install -g @alternatefutures/cli'
+                sh 'npm install -g @alternatefutures/acc'
                 sh 'acc services deploy'
             }
         }
@@ -261,7 +261,7 @@ acc services deploy <service-id>
 ```
 
 ::: tip What this maps to in code
-See the [services deploy command](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/services/index.ts). It reads `AF_TOKEN`, `AF_PROJECT_ID`, and `AF_ORG_ID` from the environment ([secrets.ts](https://github.com/alternatefutures/cloud-cli/blob/main/src/secrets.ts)). Flags such as `--name`, `--network`, `--wait`, and `--json` are not implemented.
+See the [services deploy command](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/services/index.ts). It reads `AF_TOKEN`, `AF_PROJECT_ID`, and `AF_ORG_ID` from the environment ([secrets.ts](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/secrets.ts)). Flags such as `--name`, `--network`, `--wait`, and `--json` are not implemented.
 :::
 
 ## Environment Variables
@@ -272,7 +272,7 @@ The CLI reads these environment variables:
 - `AF_PROJECT_ID` - default project id
 - `AF_ORG_ID` - default organization id
 
-See [secrets.ts](https://github.com/alternatefutures/cloud-cli/blob/main/src/secrets.ts).
+See [secrets.ts](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/secrets.ts).
 
 ## Best Practices
 

--- a/docs/guides/custom-domains.md
+++ b/docs/guides/custom-domains.md
@@ -22,9 +22,9 @@ Custom domains provide:
 - Automatic SSL/TLS certificates via Let's Encrypt
 
 ::: tip What this maps to in code
-- SDK methods live in the [`domains.ts` client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/domains.ts) (`createCustomDomain`, `verifyCustomDomain`, `provisionSsl`, `setPrimaryDomain`, `removeCustomDomain`).
-- The authoritative GraphQL surface (Domain type, mutations, `CreateDomainInput`) is in [`typeDefs.ts`](https://github.com/alternatefutures/service-cloud-api/blob/main/src/schema/typeDefs.ts).
-- Verification and SSL status fields are backed by the [Prisma `Domain` model](https://github.com/alternatefutures/service-cloud-api/blob/main/prisma/schema.prisma).
+- SDK methods live in the [`domains.ts` client](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/domains.ts) (`createCustomDomain`, `verifyCustomDomain`, `provisionSsl`, `setPrimaryDomain`, `removeCustomDomain`).
+- The authoritative GraphQL surface (Domain type, mutations, `CreateDomainInput`) is in [`typeDefs.ts`](https://github.com/alternatefutures/alternate-clouds-api/blob/main/src/schema/typeDefs.ts).
+- Verification and SSL status fields are backed by the [Prisma `Domain` model](https://github.com/alternatefutures/alternate-clouds-api/blob/main/prisma/schema.prisma).
 :::
 
 ## Adding a Custom Domain

--- a/docs/guides/deploy-astro.md
+++ b/docs/guides/deploy-astro.md
@@ -11,7 +11,7 @@ Deploy an Astro site to Alternate Clouds, the decentralized cloud platform from 
 Before you begin, make sure you have:
 
 - **An Alternate Clouds account** - [Sign up here](https://app.alternatefutures.ai)
-- **The Alternate Clouds CLI (`acc`) installed** - `npm install -g @alternatefutures/cli`
+- **The Alternate Clouds CLI (`acc`) installed** - `npm install -g @alternatefutures/acc`
 - **Node.js 18 or later** - [Download here](https://nodejs.org/en/download)
 - **An Astro project** (or create one below)
 
@@ -35,7 +35,7 @@ Astro outputs to `./dist` by default. Set `distDir` to `dist` in your `acc.confi
 :::
 
 ::: info What this maps to in code
-The commands above are the ones the CLI actually registers — see [the CLI's actual command surface](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts) (`login`, `logout`, `projects`, `services`, `deployments`, `ssh`, `billing`). The deploy subcommand lives at `acc services deploy [id]`.
+The commands above are the ones the CLI actually registers — see [the CLI's actual command surface](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts) (`login`, `logout`, `projects`, `services`, `deployments`, `ssh`, `billing`). The deploy subcommand lives at `acc services deploy [id]`.
 :::
 
 ## Step 1: Create a New Astro Project
@@ -154,7 +154,7 @@ acc services deploy
 ```
 
 ::: info What this maps to in code
-`slug`, `buildCommand`, and `distDir` are real fields in the [acc.config schema](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts).
+`slug`, `buildCommand`, and `distDir` are real fields in the [acc.config schema](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/utils/configuration/types.ts).
 :::
 
 You should see output like:
@@ -263,7 +263,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to Alternate Clouds
-        run: npx @alternatefutures/cli services deploy
+        run: npx @alternatefutures/acc services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN }}
 ```
@@ -293,7 +293,7 @@ console.log('Deployed! CID:', results[0].cid);
 ```
 
 ::: info What this maps to in code
-Signatures and the `UploadResult` shape (`{ cid, size, path }`) come from [the SDK IPFS client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipfs.ts): `add(file: IpfsFile)` for a single file, `addFromPath(path)` for a directory.
+Signatures and the `UploadResult` shape (`{ cid, size, path }`) come from [the SDK IPFS client](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/ipfs.ts): `add(file: IpfsFile)` for a single file, `addFromPath(path)` for a directory.
 :::
 
 ## Common Issues

--- a/docs/guides/deploy-nextjs.md
+++ b/docs/guides/deploy-nextjs.md
@@ -11,7 +11,7 @@ Deploy a Next.js app to Alternate Clouds, the decentralized cloud platform from 
 Before you begin, make sure you have:
 
 - **An Alternate Clouds account** - [Sign up here](https://app.alternatefutures.ai)
-- **The Alternate Clouds CLI (`acc`) installed** - `npm install -g @alternatefutures/cli`
+- **The Alternate Clouds CLI (`acc`) installed** - `npm install -g @alternatefutures/acc`
 - **Node.js 18 or later** - [Download here](https://nodejs.org/en/download)
 - **A Next.js project** (or create one below)
 
@@ -35,7 +35,7 @@ Next.js static export outputs to `./out` by default. Set `distDir` to `out` in y
 :::
 
 ::: info What this maps to in code
-These are the commands the CLI actually registers — see [the CLI's actual command surface](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts) (`login`, `logout`, `projects`, `services`, `deployments`, `ssh`, `billing`). Deploy lives at `acc services deploy [id]`.
+These are the commands the CLI actually registers — see [the CLI's actual command surface](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts) (`login`, `logout`, `projects`, `services`, `deployments`, `ssh`, `billing`). Deploy lives at `acc services deploy [id]`.
 :::
 
 ## Step 1: Create a New Next.js Project
@@ -162,7 +162,7 @@ acc services deploy
 ```
 
 ::: info What this maps to in code
-`slug`, `buildCommand`, and `distDir` are real fields in the [acc.config schema](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts).
+`slug`, `buildCommand`, and `distDir` are real fields in the [acc.config schema](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/utils/configuration/types.ts).
 :::
 
 You should see output like:
@@ -216,7 +216,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to Alternate Clouds
-        run: npx @alternatefutures/cli services deploy
+        run: npx @alternatefutures/acc services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN }}
 ```
@@ -246,7 +246,7 @@ console.log('Deployed! CID:', results[0].cid);
 ```
 
 ::: info What this maps to in code
-Signatures and the `UploadResult` shape (`{ cid, size, path }`) come from [the SDK IPFS client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipfs.ts): `add(file: IpfsFile)` for a single file, `addFromPath(path)` for a directory.
+Signatures and the `UploadResult` shape (`{ cid, size, path }`) come from [the SDK IPFS client](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/ipfs.ts): `add(file: IpfsFile)` for a single file, `addFromPath(path)` for a directory.
 :::
 
 ## Common Issues

--- a/docs/guides/deploy-react.md
+++ b/docs/guides/deploy-react.md
@@ -11,7 +11,7 @@ Deploy a React app to Alternate Clouds, the decentralized cloud platform from Al
 Before you begin, make sure you have:
 
 - **An Alternate Clouds account** - [Sign up here](https://app.alternatefutures.ai)
-- **The Alternate Clouds CLI (`acc`) installed** - `npm install -g @alternatefutures/cli`
+- **The Alternate Clouds CLI (`acc`) installed** - `npm install -g @alternatefutures/acc`
 - **Node.js 18 or later** - [Download here](https://nodejs.org/en/download)
 - **A React project** (or create one below)
 
@@ -45,7 +45,7 @@ acc services deploy
 - **Vite projects** output to `./dist` by default
 - **Create React App projects** output to `./build` by default
 
-Set `distDir` to the matching folder in your `acc.config` — it is a real field in the [acc.config schema](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts) (alongside `slug` and `buildCommand`).
+Set `distDir` to the matching folder in your `acc.config` — it is a real field in the [acc.config schema](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/utils/configuration/types.ts) (alongside `slug` and `buildCommand`).
 :::
 
 ## Step 1: Create a New React Project
@@ -185,7 +185,7 @@ acc services deploy
 :::
 
 ::: info What this maps to in code
-`acc services deploy` is the CLI's only deploy subcommand — see [the CLI's actual command surface](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts). `slug`, `buildCommand`, and `distDir` are real [acc.config schema](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts) fields.
+`acc services deploy` is the CLI's only deploy subcommand — see [the CLI's actual command surface](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts). `slug`, `buildCommand`, and `distDir` are real [acc.config schema](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/utils/configuration/types.ts) fields.
 :::
 
 You should see output like:
@@ -263,7 +263,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to Alternate Clouds
-        run: npx @alternatefutures/cli services deploy
+        run: npx @alternatefutures/acc services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN }}
 ```
@@ -293,7 +293,7 @@ console.log('Deployed! CID:', results[0].cid);
 ```
 
 ::: info What this maps to in code
-Signatures and the `UploadResult` shape (`{ cid, size, path }`) come from [the SDK IPFS client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipfs.ts): `add(file: IpfsFile)` for a single file, `addFromPath(path)` for a directory.
+Signatures and the `UploadResult` shape (`{ cid, size, path }`) come from [the SDK IPFS client](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/ipfs.ts): `add(file: IpfsFile)` for a single file, `addFromPath(path)` for a directory.
 :::
 
 ## Environment Variables

--- a/docs/guides/ens.md
+++ b/docs/guides/ens.md
@@ -7,7 +7,7 @@ description: Connect your Alternate Futures sites to ENS domains for decentraliz
 Connect your Alternate Futures sites to Ethereum Name Service (ENS) domains for decentralized, human-readable URLs.
 
 ::: tip What this maps to in code
-ENS records are managed through the SDK's [`ens.ts` client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ens.ts) (`create`, `list`, `getByName`, `verify`, `delete`). The `acc` CLI does not register an `ens` command ([cli.ts](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts)), so ENS management is SDK-only.
+ENS records are managed through the SDK's [`ens.ts` client](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/ens.ts) (`create`, `list`, `getByName`, `verify`, `delete`). The `acc` CLI does not register an `ens` command ([cli.ts](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts)), so ENS management is SDK-only.
 :::
 
 ## What is ENS?

--- a/docs/guides/functions.md
+++ b/docs/guides/functions.md
@@ -25,8 +25,8 @@ Functions run in a JavaScript/TypeScript runtime with:
 - An optional SGX (Software Guard Extensions) deployment flag for workloads that need extra isolation
 
 ::: info What this maps to in code
-- **SDK:** [functions client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/functions.ts) — `create`, `deploy`, `list`, `listDeployments`, `update`, `delete`.
-- **API:** [`AFFunction` data model](https://github.com/alternatefutures/service-cloud-api/blob/main/prisma/schema.prisma) and [`AFFunction` GraphQL type](https://github.com/alternatefutures/service-cloud-api/blob/main/src/schema/typeDefs.ts) — exposes `invokeUrl`, `routes`, `status`.
+- **SDK:** [functions client](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/functions.ts) — `create`, `deploy`, `list`, `listDeployments`, `update`, `delete`.
+- **API:** [`AFFunction` data model](https://github.com/alternatefutures/alternate-clouds-api/blob/main/prisma/schema.prisma) and [`AFFunction` GraphQL type](https://github.com/alternatefutures/alternate-clouds-api/blob/main/src/schema/typeDefs.ts) — exposes `invokeUrl`, `routes`, `status`.
 :::
 
 ::: tip CLI

--- a/docs/guides/gateways.md
+++ b/docs/guides/gateways.md
@@ -10,7 +10,7 @@ A private gateway is a dedicated IPFS endpoint you own and map to a custom domai
 
 Private Gateways are dedicated IPFS gateway endpoints you own and manage. Each gateway has a `name`, a `slug`, and an associated DNS `zone`, and can be mapped to a custom domain for branded access to your IPFS content.
 
-> **What this maps to in code:** the gateway fields exposed by the API are defined on the [PrivateGateway GraphQL type](https://github.com/alternatefutures/service-cloud-api/blob/main/src/schema/typeDefs.ts) (`name`, `slug`, `zone`).
+> **What this maps to in code:** the gateway fields exposed by the API are defined on the [PrivateGateway GraphQL type](https://github.com/alternatefutures/alternate-clouds-api/blob/main/src/schema/typeDefs.ts) (`name`, `slug`, `zone`).
 
 ## Why Use Private Gateways?
 
@@ -53,7 +53,7 @@ console.log('Gateway created:', gateway.name);
 console.log('Gateway slug:', gateway.slug);
 ```
 
-> **What this maps to in code:** the [AlternateFuturesSdk constructor](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/AlternateFuturesSdk.ts) requires `accessTokenService` and exposes the `privateGateways()` accessor; the [PrivateGatewayClient](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/privateGateway.ts) implements `create({ name, zoneId })`, `list()`, `get({ id })`, `getBySlug({ slug })`, `update({ id, name })`, and `delete({ id })`.
+> **What this maps to in code:** the [AlternateFuturesSdk constructor](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/AlternateFuturesSdk.ts) requires `accessTokenService` and exposes the `privateGateways()` accessor; the [PrivateGatewayClient](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/privateGateway.ts) implements `create({ name, zoneId })`, `list()`, `get({ id })`, `getBySlug({ slug })`, `update({ id, name })`, and `delete({ id })`.
 
 ## Listing Gateways
 

--- a/docs/guides/ipns.md
+++ b/docs/guides/ipns.md
@@ -7,7 +7,7 @@ description: Create mutable pointers to IPFS content with IPNS on Alternate Futu
 Use IPNS to create mutable pointers to your IPFS content, enabling dynamic updates without changing URLs.
 
 ::: tip What this maps to in code
-IPNS is managed entirely through the SDK's [`ipns.ts` client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipns.ts) (`createRecordForSite`, `listRecords`, `publishRecord`, `resolveName`, `deleteRecord`). The `acc` CLI does not register an `ipns` command ([cli.ts](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts)), so all examples below use the SDK.
+IPNS is managed entirely through the SDK's [`ipns.ts` client](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/ipns.ts) (`createRecordForSite`, `listRecords`, `publishRecord`, `resolveName`, `deleteRecord`). The `acc` CLI does not register an `ipns` command ([cli.ts](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts)), so all examples below use the SDK.
 :::
 
 ## What is IPNS?

--- a/docs/guides/migrate-from-fleek.md
+++ b/docs/guides/migrate-from-fleek.md
@@ -13,7 +13,7 @@ Fleek has pivoted away from Web3 hosting to focus on AI inference. If you still 
 | Feature | Fleek | Alternate Futures |
 |---------|-------|-------------------|
 | **CLI command** | `fleek` | `acc` |
-| **Package name** | `@fleekxyz/cli` | `@alternatefutures/cli` |
+| **Package name** | `@fleekxyz/cli` | `@alternatefutures/acc` |
 | **SDK package** | `@fleekxyz/sdk` | `@alternatefutures/sdk` |
 | **Config file** | `fleek.json` | `af.config.json` |
 | **Token env var** | `FLEEK_TOKEN` | `AF_TOKEN` |
@@ -36,12 +36,12 @@ Fleek has pivoted away from Web3 hosting to focus on AI inference. If you still 
 
 3. **Install the Alternate Clouds CLI:**
    ```bash
-   npm install -g @alternatefutures/cli
+   npm install -g @alternatefutures/acc
    acc login
    ```
 
    ::: warning CLI binary name
-   Commands in this guide use `acc`. If your installed version still exposes the legacy `af` binary, update to the latest `@alternatefutures/cli` or substitute `af` for `acc`.
+   Commands in this guide use `acc`. If your installed version still exposes the legacy `af` binary, update to the latest `@alternatefutures/acc` or substitute `af` for `acc`.
    :::
 
 ## Step 1: Migrate Your Site
@@ -68,7 +68,7 @@ acc services deploy [id]
 acc deployments
 ```
 
-Deploys run through `acc services`; the full set of registered top-level commands (`login`, `logout`, `projects`, `services`, `deployments`, `billing`, `ssh`) is defined in [the acc CLI command set](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts).
+Deploys run through `acc services`; the full set of registered top-level commands (`login`, `logout`, `projects`, `services`, `deployments`, `billing`, `ssh`) is defined in [the acc CLI command set](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts).
 
 If you keep an `af.config.json` in your project, here is how a `fleek.json` maps onto it:
 
@@ -95,7 +95,7 @@ If you keep an `af.config.json` in your project, here is how a `fleek.json` maps
 }
 ```
 
-> **What this maps to in code:** these fields are the [`af.config` schema (sites: slug/distDir/buildCommand)](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts).
+> **What this maps to in code:** these fields are the [`af.config` schema (sites: slug/distDir/buildCommand)](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/utils/configuration/types.ts).
 
 ### From Fleek SDK to AF SDK
 
@@ -129,7 +129,7 @@ const [result] = await af.ipfs().addFromPath('./dist');
 console.log('CID:', result.cid.toString());
 ```
 
-The import path and environment variable names change. Note one API difference: `af.ipfs().add()` takes an in-memory `{ path, content }` file, while `af.ipfs().addFromPath('./dist')` uploads a directory and returns a `UploadResult[]` — see the [IPFS client (add / addFromPath)](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipfs.ts).
+The import path and environment variable names change. Note one API difference: `af.ipfs().add()` takes an in-memory `{ path, content }` file, while `af.ipfs().addFromPath('./dist')` uploads a directory and returns a `UploadResult[]` — see the [IPFS client (add / addFromPath)](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/ipfs.ts).
 
 ## Step 2: Migrate IPFS Content
 
@@ -201,7 +201,7 @@ See the [Custom Domains guide](./custom-domains.md) for full details.
 **New (Alternate Futures):**
 ```yaml
 - name: Deploy to Alternate Futures
-  run: npx @alternatefutures/cli services deploy
+  run: npx @alternatefutures/acc services deploy
   env:
     AF_TOKEN: ${{ secrets.AF_TOKEN }}
     AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID }}
@@ -244,7 +244,7 @@ Beyond replacing Fleek's functionality, Alternate Futures provides additional fe
 
 Make sure you are installing the correct package:
 ```bash
-npm install -g @alternatefutures/cli
+npm install -g @alternatefutures/acc
 ```
 
 ### CIDs differ after re-uploading

--- a/docs/guides/migrate-from-netlify.md
+++ b/docs/guides/migrate-from-netlify.md
@@ -35,14 +35,14 @@ Migrating from Netlify works best for **static sites** and **JAMstack apps** (Ne
 
 ```bash
 # Install the Alternate Clouds CLI
-npm install -g @alternatefutures/cli
+npm install -g @alternatefutures/acc
 
 # Authenticate
 acc login
 ```
 
 ::: warning CLI binary name
-Commands here use `acc`. If your installed version still exposes the legacy `af` binary, update to the latest `@alternatefutures/cli` or substitute `af` for `acc`.
+Commands here use `acc`. If your installed version still exposes the legacy `af` binary, update to the latest `@alternatefutures/acc` or substitute `af` for `acc`.
 :::
 
 ## Step 2: Update Your Configuration
@@ -76,7 +76,7 @@ Netlify uses `netlify.toml` for configuration. You will replace this with `af.co
 }
 ```
 
-> **What this maps to in code:** these fields are the [`af.config` schema](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts).
+> **What this maps to in code:** these fields are the [`af.config` schema](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/utils/configuration/types.ts).
 
 ::: info SPA Redirects
 Netlify's `_redirects` file and redirect rules in `netlify.toml` are specific to Netlify. For single-page apps on IPFS, ensure your build produces a `200.html` or `index.html` fallback. Most SPA frameworks handle this automatically.
@@ -96,7 +96,7 @@ acc services create
 acc services deploy [id]
 ```
 
-These are the real registered commands — see [the acc CLI command set](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts).
+These are the real registered commands — see [the acc CLI command set](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts).
 
 ### Framework Output Directories
 
@@ -212,7 +212,7 @@ jobs:
         run: npm run build
 
       - name: Deploy
-        run: npx @alternatefutures/cli services deploy
+        run: npx @alternatefutures/acc services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN }}
           AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID }}
@@ -221,7 +221,7 @@ jobs:
 ### Add Secrets
 
 1. Go to your GitHub repository **Settings** > **Secrets and variables** > **Actions**
-2. Add `AF_TOKEN` -- your personal access token (create one with [`acc pat create`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/pat/index.ts) `--name "CI/CD"`)
+2. Add `AF_TOKEN` -- your personal access token (create one with [`acc pat create`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/pat/index.ts) `--name "CI/CD"`)
 3. Add `AF_PROJECT_ID` -- your project ID (find it with `acc projects list`)
 
 ## Step 6: Migrate Environment Variables

--- a/docs/guides/migrate-from-spheron.md
+++ b/docs/guides/migrate-from-spheron.md
@@ -13,7 +13,7 @@ Spheron has pivoted away from Web3 hosting to focus on GPU compute and AI infere
 | Feature | Spheron | Alternate Futures |
 |---------|---------|-------------------|
 | **CLI command** | `spheron` | `acc` |
-| **Package name** | `@spheron/cli` | `@alternatefutures/cli` |
+| **Package name** | `@spheron/cli` | `@alternatefutures/acc` |
 | **SDK package** | `@spheron/storage` | `@alternatefutures/sdk` |
 | **Config file** | `spheron.json` | `af.config.json` |
 | **Token env var** | `SPHERON_TOKEN` | `AF_TOKEN` |
@@ -41,12 +41,12 @@ If you used Spheron primarily for GPU compute, that functionality is separate fr
 
 3. **Install the Alternate Clouds CLI:**
    ```bash
-   npm install -g @alternatefutures/cli
+   npm install -g @alternatefutures/acc
    acc login
    ```
 
    ::: warning CLI binary name
-   Commands in this guide use `acc`. If your installed version still exposes the legacy `af` binary, update to the latest `@alternatefutures/cli` or substitute `af` for `acc`.
+   Commands in this guide use `acc`. If your installed version still exposes the legacy `af` binary, update to the latest `@alternatefutures/acc` or substitute `af` for `acc`.
    :::
 
 ## Step 1: Migrate Your Site
@@ -70,7 +70,7 @@ acc services create
 acc services deploy [id]
 ```
 
-These are the real registered commands — see [the acc CLI command set](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts).
+These are the real registered commands — see [the acc CLI command set](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts).
 
 If you keep an `af.config.json` in your project, here is how Spheron's configuration maps onto it:
 
@@ -93,7 +93,7 @@ If you keep an `af.config.json` in your project, here is how Spheron's configura
 }
 ```
 
-> **What this maps to in code:** these fields are the [`af.config` schema](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts).
+> **What this maps to in code:** these fields are the [`af.config` schema](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/utils/configuration/types.ts).
 
 ### From Spheron SDK to AF SDK
 
@@ -129,7 +129,7 @@ console.log('CID:', result.cid.toString());
 console.log('URL:', `https://ipfs.io/ipfs/${result.cid.toString()}`);
 ```
 
-> **What this maps to in code:** `addFromPath` returns a `UploadResult[]` of `{ cid, size, path }` — see the [IPFS client return shape (UploadResult)](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipfs.ts).
+> **What this maps to in code:** `addFromPath` returns a `UploadResult[]` of `{ cid, size, path }` — see the [IPFS client return shape (UploadResult)](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/ipfs.ts).
 
 ### Storage Protocol Mapping
 
@@ -253,7 +253,7 @@ jobs:
         run: npm run build
 
       - name: Deploy
-        run: npx @alternatefutures/cli services deploy
+        run: npx @alternatefutures/acc services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN }}
           AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID }}
@@ -262,7 +262,7 @@ jobs:
 ### Add Secrets
 
 1. Go to your GitHub repository **Settings** > **Secrets and variables** > **Actions**
-2. Add `AF_TOKEN` -- your personal access token (create one with [`acc pat create`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/pat/index.ts) `--name "CI/CD"`)
+2. Add `AF_TOKEN` -- your personal access token (create one with [`acc pat create`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/pat/index.ts) `--name "CI/CD"`)
 3. Add `AF_PROJECT_ID` -- your project ID (find it with `acc projects list`)
 
 ## Step 5: Migrate Environment Variables
@@ -320,7 +320,7 @@ Beyond replacing Spheron's hosting functionality, Alternate Futures provides add
 
 Make sure you are installing the correct package:
 ```bash
-npm install -g @alternatefutures/cli
+npm install -g @alternatefutures/acc
 ```
 
 ### CIDs differ after re-uploading

--- a/docs/guides/migrate-from-vercel.md
+++ b/docs/guides/migrate-from-vercel.md
@@ -35,14 +35,14 @@ Migrating from Vercel works best for **static sites** and **static exports** (Ne
 
 ```bash
 # Install the Alternate Clouds CLI
-npm install -g @alternatefutures/cli
+npm install -g @alternatefutures/acc
 
 # Authenticate
 acc login
 ```
 
 ::: warning CLI binary name
-Commands here use `acc`. If your installed version still exposes the legacy `af` binary, update to the latest `@alternatefutures/cli` or substitute `af` for `acc`.
+Commands here use `acc`. If your installed version still exposes the legacy `af` binary, update to the latest `@alternatefutures/acc` or substitute `af` for `acc`.
 :::
 
 ## Step 2: Configure Your Build
@@ -76,7 +76,7 @@ acc services create
 acc services deploy [id]
 ```
 
-These are the real registered commands — see [the acc CLI command set](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts).
+These are the real registered commands — see [the acc CLI command set](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts).
 
 ### React (Vite or Create React App)
 
@@ -169,7 +169,7 @@ jobs:
         run: npm run build
 
       - name: Deploy
-        run: npx @alternatefutures/cli services deploy
+        run: npx @alternatefutures/acc services deploy
         env:
           AF_TOKEN: ${{ secrets.AF_TOKEN }}
           AF_PROJECT_ID: ${{ secrets.AF_PROJECT_ID }}
@@ -178,7 +178,7 @@ jobs:
 ### Add Secrets
 
 1. Go to your GitHub repository **Settings** > **Secrets and variables** > **Actions**
-2. Add `AF_TOKEN` -- your personal access token (create one with [`acc pat create`](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/pat/index.ts) `--name "CI/CD"`)
+2. Add `AF_TOKEN` -- your personal access token (create one with [`acc pat create`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/pat/index.ts) `--name "CI/CD"`)
 3. Add `AF_PROJECT_ID` -- your project ID (find it with `acc projects list`)
 
 ## Step 5: Migrate Environment Variables

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -99,7 +99,7 @@ That's it! Your application is now sending traces, metrics, and logs to the Alte
 ## Instrumentation Setup
 
 ::: tip What this maps to in code
-`initInstrumentation` and `withSpan` are real exports of the [SDK instrumentation module](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/instrumentation/index.ts), available via the `@alternatefutures/sdk/instrumentation` subpath.
+`initInstrumentation` and `withSpan` are real exports of the [SDK instrumentation module](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/instrumentation/index.ts), available via the `@alternatefutures/sdk/instrumentation` subpath.
 :::
 
 ### Node.js Auto-Instrumentation
@@ -255,7 +255,7 @@ logger.emit({
 ### Using the SDK
 
 ::: tip What this maps to in code
-Every method below (`queryTraces`, `getTrace`, `queryLogs`, `queryMetrics`, `getServices`, `getSettings`, `updateSettings`, `getUsage`) is defined in the [observability SDK client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/observability.ts).
+Every method below (`queryTraces`, `getTrace`, `queryLogs`, `queryMetrics`, `getServices`, `getSettings`, `updateSettings`, `getUsage`) is defined in the [observability SDK client](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/observability.ts).
 :::
 
 ::: code-group
@@ -385,7 +385,7 @@ services.forEach(service => {
 ### Querying via GraphQL
 
 ::: info CLI support is on the roadmap
-There is no `acc observability` command yet. Query observability data through the SDK (`af.observability()`) or the GraphQL API. The relevant types (`ObservabilitySettings`, `TelemetryUsageSummary`) and operations (`observabilitySettings`, `telemetryUsage`, `updateObservabilitySettings`) are defined in the [observability GraphQL schema](https://github.com/alternatefutures/service-cloud-api/blob/main/src/schema/typeDefs.ts).
+There is no `acc observability` command yet. Query observability data through the SDK (`af.observability()`) or the GraphQL API. The relevant types (`ObservabilitySettings`, `TelemetryUsageSummary`) and operations (`observabilitySettings`, `telemetryUsage`, `updateObservabilitySettings`) are defined in the [observability GraphQL schema](https://github.com/alternatefutures/alternate-clouds-api/blob/main/src/schema/typeDefs.ts).
 :::
 
 <!-- Fabricated `acc observability ...` CLI code-group removed: no such command exists. -->

--- a/docs/guides/projects.md
+++ b/docs/guides/projects.md
@@ -115,9 +115,9 @@ Configure project basics:
 ### Storage Settings
 
 ::: info What this maps to in code
-- **CLI:** [projects command](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/projects/index.ts) — `list`, `create`, `update` (rename only), `switch`, `delete`.
-- **SDK:** [projects client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/projects.ts) — backup toggles via `update({ where, data: { backupStorageOnArweave, backupStorageOnFilecoin } })`.
-- **API:** [Project data model](https://github.com/alternatefutures/service-cloud-api/blob/main/prisma/schema.prisma).
+- **CLI:** [projects command](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/projects/index.ts) — `list`, `create`, `update` (rename only), `switch`, `delete`.
+- **SDK:** [projects client](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/projects.ts) — backup toggles via `update({ where, data: { backupStorageOnArweave, backupStorageOnFilecoin } })`.
+- **API:** [Project data model](https://github.com/alternatefutures/alternate-clouds-api/blob/main/prisma/schema.prisma).
 :::
 
 Backup storage is configured through the SDK. The CLI `acc projects update` only renames a project.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -41,7 +41,7 @@ The web application is currently in development. In the meantime, you can use th
 
 ```bash [CLI]
 # Install the CLI globally
-npm install -g @alternatefutures/cli
+npm install -g @alternatefutures/acc
 ```
 
 ```bash [SDK]
@@ -140,9 +140,9 @@ Environment variables store sensitive information (like tokens) outside your cod
 ### Troubleshooting Authentication
 
 **"Command not found: acc"**
-- Make sure you installed the CLI: `npm install -g @alternatefutures/cli`
+- Make sure you installed the CLI: `npm install -g @alternatefutures/acc`
 - Try restarting your terminal
-- Check installation with `npm list -g @alternatefutures/cli`
+- Check installation with `npm list -g @alternatefutures/acc`
 
 **"Login failed" or browser doesn't open**
 - Try the API key method instead

--- a/docs/guides/registry-deployment.md
+++ b/docs/guides/registry-deployment.md
@@ -573,4 +573,4 @@ Need help deploying?
 
 - [Discord Community](https://discord.gg/alternatefutures)
 - [Akash Discord](https://discord.gg/akash)
-- [GitHub Issues](https://github.com/alternatefutures/service-cloud-api/issues)
+- [GitHub Issues](https://github.com/alternatefutures/alternate-clouds-api/issues)

--- a/docs/guides/sites.md
+++ b/docs/guides/sites.md
@@ -60,7 +60,7 @@ acc deployments
 acc deployments --all
 ```
 
-> **What this maps to in code:** the CLI command surface is defined in [`cli.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts); the [`services` command (deploy/create/list)](https://github.com/alternatefutures/cloud-cli/blob/main/src/commands/services/index.ts) implements `acc services deploy [id]`. There is no `sites` command and no `--network` flag — storage network selection is not a CLI option.
+> **What this maps to in code:** the CLI command surface is defined in [`cli.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts); the [`services` command (deploy/create/list)](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/commands/services/index.ts) implements `acc services deploy [id]`. There is no `sites` command and no `--network` flag — storage network selection is not a CLI option.
 
 ## Storage Networks
 
@@ -355,7 +355,7 @@ export default {
 };
 ```
 
-> **What this maps to in code:** the [af.config site configuration schema](https://github.com/alternatefutures/cloud-cli/blob/main/src/utils/configuration/types.ts) defines the supported keys — `slug`, `distDir`, and optional `buildCommand`. There is no `output`, `command`, or `environment` (env-var injection) support today.
+> **What this maps to in code:** the [af.config site configuration schema](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/utils/configuration/types.ts) defines the supported keys — `slug`, `distDir`, and optional `buildCommand`. There is no `output`, `command`, or `environment` (env-var injection) support today.
 
 ## Custom Domains
 

--- a/docs/guides/storage.md
+++ b/docs/guides/storage.md
@@ -35,7 +35,7 @@ console.log('Directory CID:', dirResult.pin.cid);
 console.log('Size:', dirResult.pin.size);
 ```
 
-> **What this maps to in code:** upload/list/get/delete are implemented in [`StorageClient`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/storage.ts); authentication uses [`PersonalAccessTokenService`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/libs/AccessTokenService/PersonalAccessTokenService.ts). The [CLI command surface](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts) does not include storage commands.
+> **What this maps to in code:** upload/list/get/delete are implemented in [`StorageClient`](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/storage.ts); authentication uses [`PersonalAccessTokenService`](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/libs/AccessTokenService/PersonalAccessTokenService.ts). The [CLI command surface](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts) does not include storage commands.
 
 ## Storage Networks
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,7 +105,7 @@ features:
 ::: code-group
 
 ```bash [CLI]
-npm install -g @alternatefutures/cli
+npm install -g @alternatefutures/acc
 acc login
 ```
 
@@ -155,5 +155,5 @@ console.log('CID:', result.cid.toString());
 :::
 
 ::: tip What this maps to in code
-CLI commands are registered in [`src/cli.ts`](https://github.com/alternatefutures/cloud-cli/blob/main/src/cli.ts). The SDK's `ipfs().add()` / `addFromPath()` methods live in [`src/clients/ipfs.ts`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipfs.ts).
+CLI commands are registered in [`src/cli.ts`](https://github.com/alternatefutures/alternate-clouds-cli/blob/main/src/cli.ts). The SDK's `ipfs().add()` / `addFromPath()` methods live in [`src/clients/ipfs.ts`](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/ipfs.ts).
 :::

--- a/docs/sdk/api.md
+++ b/docs/sdk/api.md
@@ -51,7 +51,7 @@ const sites = await af.sites().list();
 const storage = await af.storage().list();
 ```
 
-**Methods:** (source: [`AlternateFuturesSdk`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/AlternateFuturesSdk.ts))
+**Methods:** (source: [`AlternateFuturesSdk`](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/AlternateFuturesSdk.ts))
 
 | Method | Returns | Description |
 |--------|---------|-------------|
@@ -170,7 +170,7 @@ const token = await accessTokenService.getAccessToken();
 
 ## Sites & Deployments
 
-> **What this maps to in code:** [`Site` type and the sites client](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/sites.ts) — `get({ id })`, `getBySlug({ slug })`, `list`, `create`, `delete`, `createCustomIpfsDeployment`, `getDeployment`.
+> **What this maps to in code:** [`Site` type and the sites client](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/sites.ts) — `get({ id })`, `getBySlug({ slug })`, `list`, `create`, `delete`, `createCustomIpfsDeployment`, `getDeployment`.
 
 ### Site
 
@@ -437,7 +437,7 @@ type AFFunctionStatus = "ACTIVE" | "INACTIVE";
 
 ## Billing
 
-> **What this maps to in code:** [`BillingClient`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/billing.ts) — `getCustomer`, `getActiveSubscription`, `listSubscriptions`, `getCurrentUsage`, `listInvoices`.
+> **What this maps to in code:** [`BillingClient`](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/billing.ts) — `getCustomer`, `getActiveSubscription`, `listSubscriptions`, `getCurrentUsage`, `listInvoices`.
 
 ### Customer
 
@@ -693,7 +693,7 @@ try {
 
 ## TypeScript Support
 
-All of these are re-exported from the SDK's [public entry point](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/index.ts). Import types directly from the SDK:
+All of these are re-exported from the SDK's [public entry point](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/index.ts). Import types directly from the SDK:
 
 ```typescript
 import {

--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -78,7 +78,7 @@ const sites = await af.sites().list();
 
 ## SDK Clients
 
-> **What this maps to in code:** every accessor below is defined on [`AlternateFuturesSdk`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/AlternateFuturesSdk.ts) — `sites()`, `storage()`, `ipfs()`, `ipns()`, `ens()`, `functions()`, `projects()`, `applications()`, `privateGateways()`, `user()`, `billing()`, plus `observability()` and `getVersion()`.
+> **What this maps to in code:** every accessor below is defined on [`AlternateFuturesSdk`](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/AlternateFuturesSdk.ts) — `sites()`, `storage()`, `ipfs()`, `ipns()`, `ens()`, `functions()`, `projects()`, `applications()`, `privateGateways()`, `user()`, `billing()`, plus `observability()` and `getVersion()`.
 
 | Client | Method | Description |
 |--------|--------|-------------|
@@ -145,7 +145,7 @@ const token = await accessTokenService.getAccessToken();
 
 ### Deploy a Site
 
-> **What this maps to in code:** [`af.ipfs()`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipfs.ts) exposes `add(file)`, `addAll()`, and `addFromPath(path)`, each returning `UploadResult { cid, size, path }`.
+> **What this maps to in code:** [`af.ipfs()`](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/ipfs.ts) exposes `add(file)`, `addAll()`, and `addFromPath(path)`, each returning `UploadResult { cid, size, path }`.
 
 ```typescript
 // Create a new site
@@ -176,7 +176,7 @@ await af.storage().delete({ cid: 'bafybei...' });
 
 ### Work with IPNS
 
-> **What this maps to in code:** [`af.ipns()`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipns.ts) — `createRecord`, `createRecordForSite`, `publishRecord`, `listRecords`, `getRecord`, `deleteRecord`.
+> **What this maps to in code:** [`af.ipns()`](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/ipns.ts) — `createRecord`, `createRecordForSite`, `publishRecord`, `listRecords`, `getRecord`, `deleteRecord`.
 
 ```typescript
 // Create an IPNS record for a site
@@ -194,7 +194,7 @@ const records = await af.ipns().listRecords();
 
 ### Custom Domains
 
-> **What this maps to in code:** [`af.domains()`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/domains.ts) — `createCustomDomain`, `verifyCustomDomain`, `listDomainsForSite`.
+> **What this maps to in code:** [`af.domains()`](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/domains.ts) — `createCustomDomain`, `verifyCustomDomain`, `listDomainsForSite`.
 
 ```typescript
 // Add a custom domain to a site

--- a/docs/sdk/installation.md
+++ b/docs/sdk/installation.md
@@ -76,7 +76,7 @@ The SDK supports multiple authentication approaches. Choose the one that fits yo
 
 Best for: Server-side applications, scripts, CI/CD pipelines.
 
-> **What this maps to in code:** [`PersonalAccessTokenService`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/libs/AccessTokenService/PersonalAccessTokenService.ts) — `personalAccessToken` is required; `projectId` is optional.
+> **What this maps to in code:** [`PersonalAccessTokenService`](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/libs/AccessTokenService/PersonalAccessTokenService.ts) — `personalAccessToken` is required; `projectId` is optional.
 
 ```typescript
 import { AlternateFuturesSdk, PersonalAccessTokenService } from '@alternatefutures/sdk/node';
@@ -117,7 +117,7 @@ const af = new AlternateFuturesSdk({
 
 Best for: Building applications that authenticate users via Alternate Futures.
 
-> **What this maps to in code:** [`ApplicationAccessTokenService`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/libs/AccessTokenService/ApplicationAccessTokenService.ts). Browser only — it reads `window.location.origin` and requires an auth-apps URL (via `authAppsServiceUrl` or the `SDK__AUTH_APPS_URL` env var), or the constructor throws.
+> **What this maps to in code:** [`ApplicationAccessTokenService`](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/libs/AccessTokenService/ApplicationAccessTokenService.ts). Browser only — it reads `window.location.origin` and requires an auth-apps URL (via `authAppsServiceUrl` or the `SDK__AUTH_APPS_URL` env var), or the constructor throws.
 
 ```typescript
 import { AlternateFuturesSdk, ApplicationAccessTokenService } from '@alternatefutures/sdk';
@@ -275,7 +275,7 @@ main().catch(console.error);
 
 ## Custom Configuration
 
-> **What this maps to in code:** the full option list lives in [`AlternateFuturesSdk`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/AlternateFuturesSdk.ts) as `AlternateFuturesSdkOptions`.
+> **What this maps to in code:** the full option list lives in [`AlternateFuturesSdk`](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/AlternateFuturesSdk.ts) as `AlternateFuturesSdkOptions`.
 
 ### Custom API Endpoints
 

--- a/docs/sdk/quickstart.md
+++ b/docs/sdk/quickstart.md
@@ -49,7 +49,7 @@ console.log('Sites:', sites);
 
 ### Browser
 
-> **What this maps to in code:** [`StaticAccessTokenService`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/libs/AccessTokenService/StaticAccessTokenService.ts) takes a single `accessToken` option.
+> **What this maps to in code:** [`StaticAccessTokenService`](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/libs/AccessTokenService/StaticAccessTokenService.ts) takes a single `accessToken` option.
 
 ```typescript
 import { AlternateFuturesSdk, StaticAccessTokenService } from '@alternatefutures/sdk';
@@ -78,7 +78,7 @@ for (const site of sites) {
 
 ### Upload to IPFS
 
-> **What this maps to in code:** [`af.ipfs().add`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipfs.ts) takes an `IpfsFile` object `{ content, path? }`; use `addFromPath(path)` to upload from the filesystem.
+> **What this maps to in code:** [`af.ipfs().add`](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/ipfs.ts) takes an `IpfsFile` object `{ content, path? }`; use `addFromPath(path)` to upload from the filesystem.
 
 ```typescript
 // Node.js only - upload a file from a path
@@ -120,7 +120,7 @@ const domain = await af.domains().createCustomDomain({
 
 ### Create IPNS Records
 
-> **What this maps to in code:** [`af.ipns()`](https://github.com/alternatefutures/package-cloud-sdk/blob/main/src/clients/ipns.ts) — `createRecordForSite`, `publishRecord`, `listRecords`.
+> **What this maps to in code:** [`af.ipns()`](https://github.com/alternatefutures/alternate-clouds-sdk/blob/main/src/clients/ipns.ts) — `createRecordForSite`, `publishRecord`, `listRecords`.
 
 ```typescript
 // Create an IPNS record for a site

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,7 +16,7 @@ The CLI is not installed or not in your PATH.
 
 ```bash
 # Install the CLI globally
-npm install -g @alternatefutures/cli
+npm install -g @alternatefutures/acc
 
 # Verify installation
 acc --version


### PR DESCRIPTION
Closes #31

Follow-up to #30, which grounded against a **stale local CLI checkout (v0.2.6)**. Re-grounded against latest `alternate-clouds-cli` **v1.0.2** (published npm: **@alternatefutures/acc** v1.0.3).

## Fixes
- **Wrong package name:** `@alternatefutures/cli` → `@alternatefutures/acc` (57×). The old package is abandoned at 0.3.0 (May 2026) — install docs were pointing users at a dead package.
- **Canonical code links:** 99 GitHub links repointed to the renamed repos (`alternate-clouds-cli/api/sdk`).
- **Missing commands added** (shipped, were undocumented): `chat`, `cp`, `regions`, `whoami` — verified against source with code links.
- **`services` flag drift corrected:** `acc services create`/`deploy` now document their full non-interactive flag sets; added `services env` and `services link`/`unlink`.
- **API re-verification:** all "maps to code" links + roadmap/feature-state notes re-checked against current `alternate-clouds-api` main — still accurate, no changes needed.

Build passes; zero `@alternatefutures/cli` left in source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)